### PR TITLE
Make use of Coordinator for our polling 

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -19,9 +19,6 @@ from .coordinator import OnectaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=10)
-SCAN_INTERVAL = datetime.timedelta(minutes=10)
-
 PARALLEL_UPDATES = 0
 
 SERVICE_FORCE_UPDATE = "force_update"

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -15,6 +15,8 @@ from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
 
 from .daikin_api import DaikinApi
 
+from .coordinator import OnectaDataUpdateCoordinator
+
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=10)
@@ -62,16 +64,15 @@ async def async_setup(hass, config):
 
     return True
 
-
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     """Establish connection with Daikin."""
     implementation = (
         await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+            hass, config_entry
         )
     )
 
-    daikin_api = DaikinApi(hass, entry, implementation)
+    daikin_api = DaikinApi(hass, config_entry, implementation)
 
     try:
         await daikin_api.async_get_access_token()
@@ -83,8 +84,15 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     for component in COMPONENT_TYPES:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+            hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
+
+    coordinator = OnectaDataUpdateCoordinator(hass, config_entry)
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as ex:
+        raise ConfigEntryNotReady(f"Config Not Ready: {ex}")
+
     return True
 
 async def async_unload_entry(hass, config_entry):

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -94,7 +94,6 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
 
-
     return True
 
 async def async_unload_entry(hass, config_entry):

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
+from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES, COORDINATOR
 
 from .daikin_api import DaikinApi
 
@@ -69,26 +69,31 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
         )
     )
 
+    hass.data.update({DOMAIN: {}})
+    hass.data[DOMAIN][DAIKIN_DEVICES] = {}
     daikin_api = DaikinApi(hass, config_entry, implementation)
+    hass.data[DOMAIN][DAIKIN_API] = daikin_api
 
     try:
         await daikin_api.async_get_access_token()
     except ClientError as err:
         raise ConfigEntryNotReady from err
 
-    devices = await daikin_api.getCloudDevices()
-    hass.data[DOMAIN] = {DAIKIN_API: daikin_api, DAIKIN_DEVICES: devices}
+    coordinator = OnectaDataUpdateCoordinator(hass, config_entry)
+    hass.data[DOMAIN][COORDINATOR] = coordinator
+
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as ex:
+        raise ConfigEntryNotReady(f"Config Not Ready: {ex}")
+
+#     = {DAIKIN_API: daikin_api, DAIKIN_DEVICES: daikin_api., COORDINATOR: coordinator}
 
     for component in COMPONENT_TYPES:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, component)
         )
 
-    coordinator = OnectaDataUpdateCoordinator(hass, config_entry)
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except Exception as ex:
-        raise ConfigEntryNotReady(f"Config Not Ready: {ex}")
 
     return True
 

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -123,7 +123,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for mode in modes:
             async_add_entities([DaikinClimate(device, mode, coordinator)], update_before_add=False)
 
-class DaikinClimate(CoordinatorEntity, ClimateEntity):
+class DaikinClimate(ClimateEntity):
     """Representation of a Daikin HVAC."""
     _enable_turn_on_off_backwards_compatibility = False # Remove with HA 2025.1
 
@@ -131,17 +131,11 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
     def __init__(self, device, setpoint, coordinator):
         """Initialize the climate device."""
         _LOGGER.info("Device '%s' initializing Daikin Climate for controlling %s...", device.name, setpoint)
-        super().__init__(coordinator)
         self._device = device
         self._setpoint = setpoint
 
     async def _set(self, settings):
         raise NotImplementedError
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        _LOGGER.info("Device '%s' _handle_coordinator_update", self._device.name)
-        super()._handle_coordinator_update()
 
     def climateControl(self):
         cc = None

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -137,7 +137,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
     # Setpoint is the setpoint string under temperatureControl/value/operationsModes/mode/setpoints, for example roomTemperature/leavingWaterOffset
     def __init__(self, device, setpoint, coordinator):
         """Initialize the climate device."""
-        _LOGGER.info("Device '%s' initializing Daiking Climate for controlling %s...", device.name, setpoint)
+        _LOGGER.info("Device '%s' initializing Daikin Climate for controlling %s...", device.name, setpoint)
         super().__init__(coordinator)
         self._device = device
         self._setpoint = setpoint

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -608,11 +608,6 @@ class DaikinClimate(ClimateEntity):
 
         return supported_preset_modes
 
-    async def async_update(self):
-        """Retrieve latest state."""
-        _LOGGER.debug("Device '%s' climate async_update", self._device.name)
-        await self._device.api.async_update()
-
     async def async_turn_on(self):
         """Turn device CLIMATE on."""
         cc = self.climateControl()

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -99,13 +99,6 @@ HA_FAN_TO_DAIKIN = {
     DAIKIN_FAN_TO_HA["quiet"]: "quiet",
 }
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up the Daikin HVAC platform.
-
-    Can only be called when a user accidentally mentions the platform in their
-    config. But even in that case it would have been ignored.
-    """
-
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     coordinator = hass.data[DAIKIN_DOMAIN][COORDINATOR]

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -8,7 +8,6 @@ from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.data_entry_flow import FlowResult
 
-from .daikin_api import DaikinApi
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/daikin_onecta/const.py
+++ b/custom_components/daikin_onecta/const.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.entity import (
 )
 
 DOMAIN = "daikin_onecta"
+COORDINATOR = "coordinator"
 
 DAIKIN_DATA = "daikin_data"
 DAIKIN_API = "daikin_api"

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -8,9 +8,6 @@ import logging
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_SCAN_INTERVAL,
-)
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -33,7 +30,7 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=self.scan_interval),
+            update_interval=timedelta(seconds=15),
         )
 
     async def _async_update_data(self):

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -1,0 +1,40 @@
+"""Coordinator for Daikin Onecta integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import logging
+
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
+
+_LOGGER = logging.getLogger(__name__)
+
+class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from the API."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize."""
+        self.scan_interval: int = (
+            1 * 60
+        )
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=self.scan_interval),
+        )
+
+    async def _async_update_data(self):
+        await self.hass.data[DOMAIN][DAIKIN_API].get_daikin_data()

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -21,8 +21,6 @@ from datetime import datetime, timedelta
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
-
 class DaikinApi:
     """Daikin Onecta API."""
 
@@ -134,8 +132,6 @@ class DaikinApi:
 
         self.json_data = await self.getCloudDeviceDetails()
         for dev_data in self.json_data or []:
-
             if dev_data["id"] in self.hass.data[DOMAIN][DAIKIN_DEVICES]:
-                self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(
-                    dev_data
-                )
+                self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(dev_data)
+        return self.hass.data[DOMAIN][DAIKIN_DEVICES]

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -124,8 +124,7 @@ class DaikinApi:
             res[dev_data["id"]] = device
         return res
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    async def async_update(self, **kwargs):
+    async def get_daikin_data(self):
         """Pull the latest data from Daikin only when the last patch call is more than 30 seconds ago."""
         if (datetime.now() - self._last_patch_call).total_seconds() < 30:
             _LOGGER.debug("API UPDATE skipped (just updated from UI)")

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -33,8 +33,6 @@ import re
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     sensors = []
-    prog = 0
-
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():
         managementPoints = device.daikin_data.get("managementPoints", [])
         for management_point in managementPoints:

--- a/custom_components/daikin_onecta/sensor.py
+++ b/custom_components/daikin_onecta/sensor.py
@@ -55,10 +55,8 @@ async def async_setup(hass, async_add_entities):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
-    sensors = []
-    prog = 0
     coordinator = hass.data[DAIKIN_DOMAIN][COORDINATOR]
-
+    sensors = []
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():
         managementPoints = device.daikin_data.get("managementPoints", [])
         for management_point in managementPoints:
@@ -70,7 +68,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 vv = management_point.get(value)
                 if type(vv) == dict:
                     value_value = vv.get("value")
-                    if value_value is not None and type(value_value) != dict:
+                    settable = vv.get("settable", False)
+                    values = vv.get("values", [])
+                    if value_value is not None and settable == True and "on" in values and "off" in values:
+                        # Don't create when it is settable and values on/off, thati is a switch
+                        pass
+                    elif value_value is not None and type(value_value) != dict:
                         sensor2 = DaikinValueSensor(device, coordinator, embedded_id, management_point_type, None, value)
                         sensors.append(sensor2)
 

--- a/custom_components/daikin_onecta/sensor.py
+++ b/custom_components/daikin_onecta/sensor.py
@@ -19,6 +19,13 @@ from homeassistant.components.sensor import (
 
 from homeassistant.helpers.entity import EntityCategory
 
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from homeassistant.core import callback
+
 from .daikin_base import Appliance
 
 from .const import (
@@ -31,6 +38,7 @@ from .const import (
     VALUE_SENSOR_MAPPING,
     ENABLED_DEFAULT,
     ENTITY_CATEGORY,
+    COORDINATOR,
 )
 
 import logging
@@ -49,6 +57,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     sensors = []
     prog = 0
+    coordinator = hass.data[DAIKIN_DOMAIN][COORDINATOR]
 
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():
         managementPoints = device.daikin_data.get("managementPoints", [])
@@ -62,7 +71,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 if type(vv) == dict:
                     value_value = vv.get("value")
                     if value_value is not None and type(value_value) != dict:
-                        sensor2 = DaikinValueSensor(device, embedded_id, management_point_type, None, value)
+                        sensor2 = DaikinValueSensor(device, coordinator, embedded_id, management_point_type, None, value)
                         sensors.append(sensor2)
 
             sd = management_point.get("sensoryData")
@@ -72,7 +81,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 if sensoryData is not None:
                     for sensor in sensoryData:
                         _LOGGER.info("Device '%s' provides sensor '%s'", device.name, sensor)
-                        sensor2 = DaikinValueSensor(device, embedded_id, management_point_type, "sensoryData", sensor)
+                        sensor2 = DaikinValueSensor(device, coordinator, embedded_id, management_point_type, "sensoryData", sensor)
                         sensors.append(sensor2)
 
             cd = management_point.get("consumptionData")
@@ -97,17 +106,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                                     periodName = SENSOR_PERIODS[period]
                                     sensor = f"{device.name} {management_point_type} {mode} {periodName}"
                                     _LOGGER.info("Proposing sensor '%s'", sensor)
-                                    sensorv = DaikinEnergySensor (device, embedded_id, management_point_type, mode,  period, icon)
+                                    sensorv = DaikinEnergySensor (device, coordinator, embedded_id, management_point_type, mode,  period, icon)
                                     sensors.append(sensorv)
                             else:
                                 _LOGGER.info("Ignoring consumption data '%s', not a supported operation_mode", mode)
 
     async_add_entities(sensors)
 
-class DaikinEnergySensor(SensorEntity):
+class DaikinEnergySensor(CoordinatorEntity, SensorEntity):
     """Representation of a power/energy consumption sensor."""
 
-    def __init__(self, device: Appliance, embedded_id, management_point_type, operation_mode,  period, icon) -> None:
+    def __init__(self, device: Appliance, coordinator, embedded_id, management_point_type, operation_mode,  period, icon) -> None:
+        super().__init__(coordinator)
         self._device = device
         self._embedded_id = embedded_id
         self._management_point_type = management_point_type
@@ -120,11 +130,20 @@ class DaikinEnergySensor(SensorEntity):
         self._attr_entity_category = None
         self._attr_icon = icon
         self._attr_has_entity_name = True
+        self._state = self.sensor_value()
         _LOGGER.info("Device '%s:%s' supports sensor '%s'", device.name, self._embedded_id, self._attr_name)
 
     @property
     def state(self):
         """Return the state of the sensor."""
+        return self._state
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._state = self.sensor_value()
+        self.async_write_ha_state()
+
+    def sensor_value(self):
         energy_value = None
         for management_point in self._device.daikin_data["managementPoints"]:
             if self._embedded_id == management_point["embeddedId"]:
@@ -172,10 +191,11 @@ class DaikinEnergySensor(SensorEntity):
     def device_class(self):
         return SensorDeviceClass.ENERGY
 
-class DaikinValueSensor(SensorEntity):
+class DaikinValueSensor(CoordinatorEntity, SensorEntity):
 
-    def __init__(self, device: Appliance, embedded_id, management_point_type, sub_type, value) -> None:
+    def __init__(self, device: Appliance, coordinator, embedded_id, management_point_type, sub_type, value) -> None:
         _LOGGER.info("DaikinValueSensor '%s' '%s' '%s'", management_point_type, sub_type, value);
+        super().__init__(coordinator)
         self._device = device
         self._embedded_id = embedded_id
         self._management_point_type = management_point_type
@@ -200,12 +220,16 @@ class DaikinValueSensor(SensorEntity):
         readable = re.findall('[A-Z][^A-Z]*', myname)
         self._attr_name = f"{mpt} {' '.join(readable)}"
         self._attr_unique_id = f"{self._device.getId()}_{self._management_point_type}_{self._sub_type}_{self._value}"
+        self._state = self.sensor_value()
         _LOGGER.info("Device '%s:%s' supports sensor '%s'", device.name, self._embedded_id, self._attr_name)
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        result = None
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._state = self.sensor_value()
+        self.async_write_ha_state()
+
+    def sensor_value(self):
+        res = None
         managementPoints = self._device.daikin_data.get("managementPoints", [])
         for management_point in managementPoints:
             if self._embedded_id == management_point["embeddedId"]:
@@ -214,9 +238,14 @@ class DaikinValueSensor(SensorEntity):
                     management_point = management_point.get(self._sub_type).get("value")
                 cd = management_point.get(self._value)
                 if cd is not None:
-                    result = cd.get("value")
-        _LOGGER.debug("Device '%s' sensor '%s' value '%s'", self._device.name, self._value, result)
-        return result
+                    res = cd.get("value")
+        _LOGGER.debug("Device '%s' sensor '%s' value '%s'", self._device.name, self._value, res)
+        return res
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
 
     @property
     def available(self):

--- a/custom_components/daikin_onecta/switch.py
+++ b/custom_components/daikin_onecta/switch.py
@@ -11,6 +11,11 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
 from .const import (
     DOMAIN as DAIKIN_DOMAIN,
     DAIKIN_DEVICES,
@@ -19,7 +24,10 @@ from .const import (
     VALUE_SENSOR_MAPPING,
     ENABLED_DEFAULT,
     ENTITY_CATEGORY,
+    COORDINATOR,
 )
+
+from homeassistant.core import callback
 
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS,
@@ -31,7 +39,8 @@ _LOGGER = logging.getLogger(__name__)
 import re
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up Daikin climate based on config_entry."""
+    """Set up Daikin switches based on config_entry."""
+    coordinator = hass.data[DAIKIN_DOMAIN][COORDINATOR]
     sensors = []
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():
         managementPoints = device.daikin_data.get("managementPoints", [])
@@ -48,15 +57,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     values = vv.get("values", [])
                     if value_value is not None and settable == True and "on" in values and "off" in values:
                         _LOGGER.info("Device '%s' provides switch on/off '%s'", device.name, value)
-                        sensor2 = DaikinSwitch(device, embedded_id, management_point_type, value)
+                        sensor2 = DaikinSwitch(device, coordinator, embedded_id, management_point_type, value)
                         sensors.append(sensor2)
 
     async_add_entities(sensors)
 
-class DaikinSwitch(ToggleEntity):
+class DaikinSwitch(CoordinatorEntity, ToggleEntity):
 
-    def __init__(self, device: Appliance, embedded_id, management_point_type, value) -> None:
+    def __init__(self, device: Appliance, coordinator, embedded_id, management_point_type, value) -> None:
         _LOGGER.info("DaikinSwitch '%s' '%s'", management_point_type, value);
+        super().__init__(coordinator)
         self._device = device
         self._embedded_id = embedded_id
         self._management_point_type = management_point_type
@@ -80,7 +90,13 @@ class DaikinSwitch(ToggleEntity):
         readable = re.findall('[A-Z][^A-Z]*', myname)
         self._attr_name = f"{mpt} {' '.join(readable)}"
         self._attr_unique_id = f"{self._device.getId()}_{self._management_point_type}_{self._value}"
+        self._switch_state = self.sensor_value()
         _LOGGER.info("Device '%s:%s' supports sensor '%s'", device.name, self._embedded_id, self._attr_name)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._switch_state = self.sensor_value()
+        self.async_write_ha_state()
 
     @property
     def available(self):
@@ -89,8 +105,11 @@ class DaikinSwitch(ToggleEntity):
 
     @property
     def is_on(self):
+        return self._switch_state == "on"
+
+    def sensor_value(self):
         """Return the state of the switch."""
-        result = None
+        result = ""
         managementPoints = self._device.daikin_data.get("managementPoints", [])
         for management_point in managementPoints:
             if self._embedded_id == management_point["embeddedId"]:
@@ -100,7 +119,7 @@ class DaikinSwitch(ToggleEntity):
                     if cd is not None:
                         result = cd.get("value")
         _LOGGER.debug("Device '%s' switch '%s' value '%s'", self._device.name, self._value, result)
-        return result == "on"
+        return result
 
     @property
     def device_info(self):
@@ -111,13 +130,10 @@ class DaikinSwitch(ToggleEntity):
         """Turn the zone on."""
         result = await self._device.set_path(self._device.getId(), self._embedded_id, self._value, "", "on")
         if result is False:
-          _LOGGER.warning("Device '%s' problem setting '%s' to on", self._device.name, self._value)
+            _LOGGER.warning("Device '%s' problem setting '%s' to on", self._device.name, self._value)
         else:
-          for management_point in self._device.daikin_data["managementPoints"]:
-              if self._embedded_id == management_point["embeddedId"]:
-                  management_point_type = management_point["managementPointType"]
-                  if self._management_point_type == management_point_type:
-                    management_point[self._value]["value"] = "on"
+            self._switch_state = "on"
+        self.async_write_ha_state()
         return result
 
     async def async_turn_off(self, **kwargs):
@@ -126,9 +142,6 @@ class DaikinSwitch(ToggleEntity):
         if result is False:
           _LOGGER.warning("Device '%s' problem setting '%s' to off", self._device.name, self._value)
         else:
-          for management_point in self._device.daikin_data["managementPoints"]:
-              if self._embedded_id == management_point["embeddedId"]:
-                  management_point_type = management_point["managementPointType"]
-                  if self._management_point_type == management_point_type:
-                    management_point[self._value]["value"] = "off"
+            self._switch_state = "off"
+        self.async_write_ha_state()
         return result

--- a/custom_components/daikin_onecta/switch.py
+++ b/custom_components/daikin_onecta/switch.py
@@ -33,9 +33,6 @@ import re
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     sensors = []
-    prog = 0
-
-    #sensor.altherma_daily_heat_energy_consumption, altherma_daily_heat_tank_energy_consumption
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():
         managementPoints = device.daikin_data.get("managementPoints", [])
         for management_point in managementPoints:

--- a/custom_components/daikin_onecta/switch.py
+++ b/custom_components/daikin_onecta/switch.py
@@ -30,13 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 
 import re
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up the platform.
-
-    Can only be called when a user accidentally mentions the platform in their
-    config. But even in that case it would have been ignored.
-    """
-
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Daikin climate based on config_entry."""
     sensors = []

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -22,13 +22,6 @@ from .const import (
     ATTR_STATE_ON,
 )
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Old way of setting up the Daikin HVAC platform.
-
-    Can only be called when a user accidentally mentions the platform in their
-    config. But even in that case it would have been ignored.
-    """
-
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin water tank entities."""
     for dev_id, device in hass.data[DAIKIN_DOMAIN][DAIKIN_DEVICES].items():


### PR DESCRIPTION
* Make use of the HomeAssitant Coordinator to handle our polling, default 10 minutes
* The sensors and switches have been rewritten to store a cached value, other entities need some more work/time
* For any switch we also had a sensor with the same value, with this PR only a switch is available else the cached value could cause an inconsistency
* Removed some old code