### PR TITLE
Rate limitation changes

### DIFF
--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -122,7 +122,6 @@ class DaikinApi:
                     self.hass,
                     DOMAIN,
                     "day_rate_limit",
-                    breaks_in_ha_version="2022.9.0",
                     is_fixable=False,
                     is_persistent=True,
                     severity=ir.IssueSeverity.ERROR,

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -9,6 +9,7 @@ import requests
 from homeassistant import config_entries
 from homeassistant import core
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DAIKIN_DEVICES
 from .const import DOMAIN
@@ -84,10 +85,16 @@ class DaikinApi:
                 _LOGGER.error("REQUEST FAILED: %s", e)
                 return []
 
-            self.rate_limits["minute"] = res.headers.get("X-RateLimit-Limit-minute", 0)
-            self.rate_limits["day"] = res.headers.get("X-RateLimit-Limit-day", 0)
-            self.rate_limits["remaining_minutes"] = res.headers.get("X-RateLimit-Remaining-minute", 0)
-            self.rate_limits["remaining_day"] = res.headers.get("X-RateLimit-Remaining-day", 0)
+            self.rate_limits["minute"] = int(res.headers.get("X-RateLimit-Limit-minute", 0))
+            self.rate_limits["day"] = int(res.headers.get("X-RateLimit-Limit-day", 0))
+            self.rate_limits["remaining_minutes"] = int(res.headers.get("X-RateLimit-Remaining-minute", 0))
+            self.rate_limits["remaining_day"] = int(res.headers.get("X-RateLimit-Remaining-day", 0))
+
+            if self.rate_limits["remaining_minutes"] > 0:
+                ir.async_delete_issue(self.hass, DOMAIN, "minute_rate_limit")
+
+            if self.rate_limits["remaining_day"] > 0:
+                ir.async_delete_issue(self.hass, DOMAIN, "day_rate_limit")
 
             _LOGGER.debug("BEARER RESPONSE CODE: %s LIMIT: %s", res.status_code, self.rate_limits)
 
@@ -98,9 +105,34 @@ class DaikinApi:
                 _LOGGER.error("RETRIEVE JSON FAILED: %s", res.text)
                 return False
         elif res.status_code == 429:
-            raise Exception(
-                "Rate limit: Remaining minute " + str(self.rate_limits["remaining_minutes"]) + " day " + str(self.rate_limits["remaining_day"])
-            )
+            if self.rate_limits["remaining_minutes"] == 0:
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "minute_rate_limit",
+                    is_fixable=False,
+                    is_persistent=True,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/rate_limitation",
+                    translation_key="minute_rate_limit",
+                )
+
+            if self.rate_limits["remaining_day"] == 0:
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "day_rate_limit",
+                    breaks_in_ha_version="2022.9.0",
+                    is_fixable=False,
+                    is_persistent=True,
+                    severity=ir.IssueSeverity.ERROR,
+                    learn_more_url="https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/rate_limitation",
+                    translation_key="day_rate_limit",
+                )
+            if options is not None and "method" in options and options["method"] == "PATCH":
+                return False
+            else:
+                return []
         elif res.status_code == 204:
             self._last_patch_call = datetime.now()
             return True

--- a/custom_components/daikin_onecta/strings.json
+++ b/custom_components/daikin_onecta/strings.json
@@ -35,5 +35,15 @@
         "title": "Daikin Onecta"
       }
     }
+  },
+  "issues": {
+    "day_rate_limit": {
+      "title": "The daily rate limit has been reached",
+      "description": "You have reached your daily rate limit to the Daikin Cloud, check your polling frequency in the Daikin Onecta configuration."
+    },
+    "minute_rate_limit": {
+      "title": "The minute rate limit has been reached",
+      "description": "You have reached your minute rate limit to the Daikin Cloud, don't make so many calls to your Daikin devices in one minute."
+    }
   }
 }

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -63,5 +63,15 @@
         }
       }
     }
+  },
+  "issues": {
+    "day_rate_limit": {
+      "title": "The daily rate limit has been reached",
+      "description": "You have reached your daily rate limit to the Daikin Cloud, check your polling frequency in the Daikin Onecta configuration."
+    },
+    "minute_rate_limit": {
+      "title": "The minute rate limit has been reached",
+      "description": "You have reached your minute rate limit to the Daikin Cloud, don't make so many calls to your Daikin devices in one minute."
+    }
   }
 }


### PR DESCRIPTION
When we hit a rate limit we create a HA issue to inform the user, when it is the daily limit the next poll interval will be multiplied by 2 to reduce the rate we poll, any poll that results in a rate limit error will be counted as call.