### PR TITLE
Check and use ratelimit-reset and retry-after from the reply header

### DIFF
--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -70,19 +70,19 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
 
     def determine_update_interval(self, hass: HomeAssistant):
         # Default of low scan minutes interval
-        scan_interval = self.options.get("low_scan_interval", 30)
+        scan_interval = self.options.get("low_scan_interval", 30) * 60
         hs = datetime.strptime(self.options.get("high_scan_start", "07:00:00"), "%H:%M:%S").time()
         ls = datetime.strptime(self.options.get("low_scan_start", "22:00:00"), "%H:%M:%S").time()
         if self.in_between(datetime.now().time(), hs, ls):
-            scan_interval = self.options.get("high_scan_interval", 10)
+            scan_interval = self.options.get("high_scan_interval", 10) * 60
 
         # When we hit our daily rate limit we skip the next update because any call which results
         # again in just a rate limit error back is counted as call for the limit of next day
         daikin_api = hass.data[DOMAIN][DAIKIN_API]
         if daikin_api.rate_limits["remaining_day"] == 0:
-            scan_interval *= 2
+            scan_interval = max(daikin_api.rate_limits["retry_after"] + 60, scan_interval)
 
-        return timedelta(minutes=scan_interval)
+        return timedelta(seconds=scan_interval)
 
     def in_between(self, now, start, end):
         if start <= end:

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -45,6 +45,8 @@ class DaikinApi:
             "day": 0,
             "remaining_minutes": 0,
             "remaining_day": 0,
+            "retry_after": 0,
+            "ratelimit_reset": 0
         }
 
         # The following lock is used to serialize http requests to Daikin cloud
@@ -89,6 +91,9 @@ class DaikinApi:
             self.rate_limits["day"] = int(res.headers.get("X-RateLimit-Limit-day", 0))
             self.rate_limits["remaining_minutes"] = int(res.headers.get("X-RateLimit-Remaining-minute", 0))
             self.rate_limits["remaining_day"] = int(res.headers.get("X-RateLimit-Remaining-day", 0))
+            self.rate_limits["remaining_minutes"] = int(res.headers.get("X-RateLimit-Remaining-minute", 0))
+            self.rate_limits["retry_after"] = int(res.headers.get("retry-after", 0))
+            self.rate_limits["ratelimit_reset"] = int(res.headers.get("ratelimit-reset", 0))
 
             if self.rate_limits["remaining_minutes"] > 0:
                 ir.async_delete_issue(self.hass, DOMAIN, "minute_rate_limit")


### PR DESCRIPTION
    * custom_components/daikin_onecta/coordinator.py:
    * custom_components/daikin_onecta/daikin_api.py: