### PR TITLE
Add a select entity for showing the schedules available, none when no…

### DIFF
--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -160,6 +160,7 @@ class DaikinDemandSelect(CoordinatorEntity, SelectEntity):
                             opt.append(mode)
         return opt
 
+
 class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
     """Daikin Schecule Select class."""
 

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -29,6 +29,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 _LOGGER.info("Device '%s' provides demandControl", device.name)
                 sensors.append(DaikinDemandSelect(device, coordinator, embedded_id, management_point_type, "demandControl"))
 
+            # When we have a schedule we provide a select sensor
+            demand = management_point.get("schedule")
+            if demand is not None:
+                _LOGGER.info("Device '%s' provides schedule", device.name)
+                sensors.append(DaikinScheduleSelect(device, coordinator, embedded_id, management_point_type, "schedule"))
+
     async_add_entities(sensors)
 
 
@@ -152,4 +158,82 @@ class DaikinDemandSelect(CoordinatorEntity, SelectEntity):
                                 opt.append(str(val))
                         else:
                             opt.append(mode)
+        return opt
+
+class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
+    """Daikin Schecule Select class."""
+
+    def __init__(self, device: DaikinOnectaDevice, coordinator, embedded_id, management_point_type, value) -> None:
+        _LOGGER.info("DaikinScheduleSelect '%s' '%s'", management_point_type, value)
+        super().__init__(coordinator)
+        self._device = device
+        self._embedded_id = embedded_id
+        self._management_point_type = management_point_type
+        self._value = value
+        mpt = management_point_type[0].upper() + management_point_type[1:]
+        myname = value[0].upper() + value[1:]
+        readable = re.findall("[A-Z][^A-Z]*", myname)
+        self._attr_name = f"{mpt} {' '.join(readable)}"
+        self._attr_unique_id = f"{self._device.id}_{self._management_point_type}_{self._value}"
+        self._attr_has_entity_name = True
+        self.update_state()
+        _LOGGER.info(
+            "Device '%s:%s' supports sensor '%s'",
+            device.name,
+            self._embedded_id,
+            self._attr_name,
+        )
+
+    def update_state(self) -> None:
+        self._attr_options = self.get_options()
+        self._attr_current_option = self.get_current_option()
+        self._attr_available = self._device.available
+        self._attr_device_info = self._device.device_info()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.update_state()
+        self.async_write_ha_state()
+
+    def get_current_option(self):
+        """Return the state of the sensor."""
+        res = None
+        for management_point in self._device.daikin_data["managementPoints"]:
+            if self._embedded_id == management_point["embeddedId"]:
+                management_point_type = management_point["managementPointType"]
+                if self._management_point_type == management_point_type:
+                    scheduledict = management_point[self._value]
+                    if scheduledict is not None:
+                        currentMode = scheduledict["value"]["currentMode"]["value"]
+                        # When there is no schedule enabled we return none
+                        if not scheduledict["value"]["modes"][currentMode]["enabled"]["value"]:
+                            res = "none"
+                        else:
+                            currentSchedule = scheduledict["value"]["modes"][currentMode]["currentSchedule"]["value"]
+                            res = scheduledict["value"]["modes"][currentMode]["schedules"][currentSchedule]["name"]["value"]
+                            if not res:
+                                res = currentSchedule
+        return res
+
+    async def async_select_option(self, option: str) -> None:
+        return True
+
+    def get_options(self):
+        opt = []
+        for management_point in self._device.daikin_data["managementPoints"]:
+            if self._embedded_id == management_point["embeddedId"]:
+                management_point_type = management_point["managementPointType"]
+                if self._management_point_type == management_point_type:
+                    scheduledict = management_point[self._value]
+                    if scheduledict is not None:
+                        currentMode = scheduledict["value"]["currentMode"]["value"]
+                        for scheduleName in scheduledict["value"]["modes"][currentMode]["currentSchedule"]["values"]:
+                            readableName = scheduledict["value"]["modes"][currentMode]["schedules"][scheduleName]["name"]["value"]
+                            # The schedule can maybe have an empty name set, use at that moment the internal ID
+                            if not readableName:
+                                readableName = scheduleName
+                            opt.append(readableName)
+
+        opt.append("none")
+
         return opt

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -683,6 +683,112 @@
     'state': 'off',
   })
 # ---
+# name: test_altherma[select.altherma_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_altherma[select.altherma_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_altherma[select.johnny_maaike_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.johnny_maaike_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '32db6075-b739-4026-b661-127009254b42_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_altherma[select.johnny_maaike_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.johnny_maaike_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
 # name: test_altherma[select.linde_climatecontrol_demand_control-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -734,7 +840,7 @@
 # name: test_altherma[select.linde_climatecontrol_demand_control-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Demand Control',
+      'friendly_name': 'Sanne ClimateControl Demand Control',
       'options': list([
         'off',
         'auto',
@@ -758,6 +864,171 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'auto',
+  })
+# ---
+# name: test_altherma[select.linde_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.linde_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_altherma[select.linde_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.linde_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_altherma[select.sanne_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.sanne_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_altherma[select.sanne_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.sanne_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_altherma[select.werkkamer_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_altherma[select.werkkamer_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
   })
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_control_mode-entry]
@@ -793,7 +1064,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_control_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Control Mode',
+      'friendly_name': 'Sanne ClimateControl Control Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -839,7 +1110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -887,7 +1158,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -935,7 +1206,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -980,7 +1251,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1026,7 +1297,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1074,7 +1345,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1122,7 +1393,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1167,7 +1438,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1210,7 +1481,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1253,7 +1524,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_is_in_emergency_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Emergency State',
+      'friendly_name': 'Sanne ClimateControl Is In Emergency State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1296,7 +1567,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1339,7 +1610,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Installer State',
+      'friendly_name': 'Sanne ClimateControl Is In Installer State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1382,7 +1653,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1428,7 +1699,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Leaving Water Temperature',
+      'friendly_name': 'Sanne ClimateControl Leaving Water Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -1473,7 +1744,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1519,7 +1790,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -1567,7 +1838,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -1612,7 +1883,7 @@
 # name: test_altherma[sensor.altherma_climatecontrol_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Setpoint Mode',
+      'friendly_name': 'Sanne ClimateControl Setpoint Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1655,7 +1926,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Error Code',
+      'friendly_name': 'Sanne DomesticHotWaterTank Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1701,7 +1972,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1749,7 +2020,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1797,7 +2068,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1842,7 +2113,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Icon Id',
+      'friendly_name': 'Sanne DomesticHotWaterTank Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1885,7 +2156,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is Holiday Mode Active',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1928,7 +2199,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_in_emergency_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Emergency State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Emergency State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1971,7 +2242,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Error State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2014,7 +2285,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Installer State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Installer State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2057,7 +2328,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Warning State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2100,7 +2371,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is Powerful Mode Active',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2143,7 +2414,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Name',
+      'friendly_name': 'Sanne DomesticHotWaterTank Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2186,7 +2457,7 @@
 # name: test_altherma[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Setpoint Mode',
+      'friendly_name': 'Sanne DomesticHotWaterTank Setpoint Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -2232,7 +2503,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde DomesticHotWaterTank Tank Temperature',
+      'friendly_name': 'Sanne DomesticHotWaterTank Tank Temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -2277,7 +2548,7 @@
 # name: test_altherma[sensor.altherma_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2320,7 +2591,7 @@
 # name: test_altherma[sensor.altherma_gateway_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Icon Id',
+      'friendly_name': 'Sanne Gateway Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2363,7 +2634,7 @@
 # name: test_altherma[sensor.altherma_gateway_ip_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ip Address',
+      'friendly_name': 'Sanne Gateway Ip Address',
       'icon': 'mdi:ip-network',
     }),
     'context': <ANY>,
@@ -2406,7 +2677,7 @@
 # name: test_altherma[sensor.altherma_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2449,7 +2720,7 @@
 # name: test_altherma[sensor.altherma_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2492,7 +2763,7 @@
 # name: test_altherma[sensor.altherma_gateway_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Name',
+      'friendly_name': 'Sanne Gateway Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2535,7 +2806,7 @@
 # name: test_altherma[sensor.altherma_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -2578,7 +2849,7 @@
 # name: test_altherma[sensor.altherma_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -2621,7 +2892,7 @@
 # name: test_altherma[sensor.altherma_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -2667,7 +2938,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -2712,7 +2983,7 @@
 # name: test_altherma[sensor.altherma_indoorunithydro_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnitHydro Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2755,7 +3026,7 @@
 # name: test_altherma[sensor.altherma_indoorunithydro_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Icon Id',
+      'friendly_name': 'Sanne IndoorUnitHydro Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2798,7 +3069,7 @@
 # name: test_altherma[sensor.altherma_indoorunithydro_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Model Info',
+      'friendly_name': 'Sanne IndoorUnitHydro Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2841,7 +3112,7 @@
 # name: test_altherma[sensor.altherma_indoorunithydro_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Name',
+      'friendly_name': 'Sanne IndoorUnitHydro Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2884,7 +3155,7 @@
 # name: test_altherma[sensor.altherma_indoorunithydro_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Software Version',
+      'friendly_name': 'Sanne IndoorUnitHydro Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2927,7 +3198,7 @@
 # name: test_altherma[sensor.altherma_outdoorunit_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Icon Id',
+      'friendly_name': 'Sanne OutdoorUnit Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -2970,7 +3241,7 @@
 # name: test_altherma[sensor.altherma_outdoorunit_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Model Info',
+      'friendly_name': 'Sanne OutdoorUnit Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3013,7 +3284,7 @@
 # name: test_altherma[sensor.altherma_outdoorunit_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Name',
+      'friendly_name': 'Sanne OutdoorUnit Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3056,7 +3327,7 @@
 # name: test_altherma[sensor.altherma_outdoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Software Version',
+      'friendly_name': 'Sanne OutdoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3101,7 +3372,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3147,7 +3418,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3193,7 +3464,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3239,7 +3510,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3285,7 +3556,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3331,7 +3602,7 @@
 # name: test_altherma[sensor.altherma_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -3375,7 +3646,7 @@
 # name: test_altherma[sensor.altherma_userinterface_date_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Date Time',
+      'friendly_name': 'Sanne UserInterface Date Time',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3418,7 +3689,7 @@
 # name: test_altherma[sensor.altherma_userinterface_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Firmware Version',
+      'friendly_name': 'Sanne UserInterface Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3461,7 +3732,7 @@
 # name: test_altherma[sensor.altherma_userinterface_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Icon Id',
+      'friendly_name': 'Sanne UserInterface Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3504,7 +3775,7 @@
 # name: test_altherma[sensor.altherma_userinterface_micon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Micon Id',
+      'friendly_name': 'Sanne UserInterface Micon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3547,7 +3818,7 @@
 # name: test_altherma[sensor.altherma_userinterface_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Name',
+      'friendly_name': 'Sanne UserInterface Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3590,7 +3861,7 @@
 # name: test_altherma[sensor.altherma_userinterface_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Software Version',
+      'friendly_name': 'Sanne UserInterface Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3636,7 +3907,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3684,7 +3955,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3732,7 +4003,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3777,7 +4048,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -3823,7 +4094,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3871,7 +4142,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3919,7 +4190,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -3964,7 +4235,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4007,7 +4278,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4050,7 +4321,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4093,7 +4364,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4136,7 +4407,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4179,7 +4450,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4222,7 +4493,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4265,7 +4536,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4308,7 +4579,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4351,7 +4622,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4394,7 +4665,7 @@
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.johnny_maaike_climatecontrol_outdoor_silent_mode',
@@ -4439,7 +4710,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -4487,7 +4758,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -4532,7 +4803,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4575,7 +4846,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4618,7 +4889,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4661,7 +4932,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4704,7 +4975,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4747,7 +5018,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4790,7 +5061,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4833,7 +5104,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -4876,7 +5147,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -4919,7 +5190,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -4962,7 +5233,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5005,7 +5276,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -5051,7 +5322,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -5096,7 +5367,7 @@
 # name: test_altherma[sensor.johnny_maaike_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -5139,7 +5410,7 @@
 # name: test_altherma[sensor.johnny_maaike_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5182,7 +5453,7 @@
 # name: test_altherma[sensor.johnny_maaike_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5225,7 +5496,7 @@
 # name: test_altherma[sensor.johnny_maaike_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5268,7 +5539,7 @@
 # name: test_altherma[sensor.johnny_maaike_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5311,7 +5582,7 @@
 # name: test_altherma[sensor.johnny_maaike_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5354,7 +5625,7 @@
 # name: test_altherma[sensor.johnny_maaike_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5399,7 +5670,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5445,7 +5716,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5491,7 +5762,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5537,7 +5808,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5583,7 +5854,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5629,7 +5900,7 @@
 # name: test_altherma[sensor.johnny_maaike_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -5676,7 +5947,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -5724,7 +5995,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -5772,7 +6043,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -5817,7 +6088,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -5863,7 +6134,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -5911,7 +6182,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -5959,7 +6230,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -6004,7 +6275,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6047,7 +6318,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6090,7 +6361,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6133,7 +6404,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6176,7 +6447,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6219,7 +6490,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6262,7 +6533,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6305,7 +6576,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6348,7 +6619,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6391,7 +6662,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6434,7 +6705,7 @@
 # name: test_altherma[sensor.linde_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.linde_climatecontrol_outdoor_silent_mode',
@@ -6479,7 +6750,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -6527,7 +6798,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -6572,7 +6843,7 @@
 # name: test_altherma[sensor.linde_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6615,7 +6886,7 @@
 # name: test_altherma[sensor.linde_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6658,7 +6929,7 @@
 # name: test_altherma[sensor.linde_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6701,7 +6972,7 @@
 # name: test_altherma[sensor.linde_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6744,7 +7015,7 @@
 # name: test_altherma[sensor.linde_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6787,7 +7058,7 @@
 # name: test_altherma[sensor.linde_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6830,7 +7101,7 @@
 # name: test_altherma[sensor.linde_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6873,7 +7144,7 @@
 # name: test_altherma[sensor.linde_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -6916,7 +7187,7 @@
 # name: test_altherma[sensor.linde_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -6959,7 +7230,7 @@
 # name: test_altherma[sensor.linde_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -7002,7 +7273,7 @@
 # name: test_altherma[sensor.linde_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7045,7 +7316,7 @@
 # name: test_altherma[sensor.linde_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -7091,7 +7362,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -7136,7 +7407,7 @@
 # name: test_altherma[sensor.linde_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -7179,7 +7450,7 @@
 # name: test_altherma[sensor.linde_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7222,7 +7493,7 @@
 # name: test_altherma[sensor.linde_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7265,7 +7536,7 @@
 # name: test_altherma[sensor.linde_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7308,7 +7579,7 @@
 # name: test_altherma[sensor.linde_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7351,7 +7622,7 @@
 # name: test_altherma[sensor.linde_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7394,7 +7665,7 @@
 # name: test_altherma[sensor.linde_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7439,7 +7710,7 @@
 # name: test_altherma[sensor.linde_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7485,7 +7756,7 @@
 # name: test_altherma[sensor.linde_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7531,7 +7802,7 @@
 # name: test_altherma[sensor.linde_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7577,7 +7848,7 @@
 # name: test_altherma[sensor.linde_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7623,7 +7894,7 @@
 # name: test_altherma[sensor.linde_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7669,7 +7940,7 @@
 # name: test_altherma[sensor.linde_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7716,7 +7987,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -7764,7 +8035,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -7812,7 +8083,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -7857,7 +8128,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -7903,7 +8174,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -7951,7 +8222,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -7999,7 +8270,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -8044,7 +8315,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8087,7 +8358,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8130,7 +8401,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8173,7 +8444,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8216,7 +8487,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8259,7 +8530,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8302,7 +8573,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8345,7 +8616,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8388,7 +8659,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8431,7 +8702,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8474,7 +8745,7 @@
 # name: test_altherma[sensor.sanne_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.sanne_climatecontrol_outdoor_silent_mode',
@@ -8519,7 +8790,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -8567,7 +8838,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -8612,7 +8883,7 @@
 # name: test_altherma[sensor.sanne_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8655,7 +8926,7 @@
 # name: test_altherma[sensor.sanne_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8698,7 +8969,7 @@
 # name: test_altherma[sensor.sanne_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8741,7 +9012,7 @@
 # name: test_altherma[sensor.sanne_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8784,7 +9055,7 @@
 # name: test_altherma[sensor.sanne_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8827,7 +9098,7 @@
 # name: test_altherma[sensor.sanne_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8870,7 +9141,7 @@
 # name: test_altherma[sensor.sanne_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8913,7 +9184,7 @@
 # name: test_altherma[sensor.sanne_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -8956,7 +9227,7 @@
 # name: test_altherma[sensor.sanne_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -8999,7 +9270,7 @@
 # name: test_altherma[sensor.sanne_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -9042,7 +9313,7 @@
 # name: test_altherma[sensor.sanne_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9085,7 +9356,7 @@
 # name: test_altherma[sensor.sanne_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -9131,7 +9402,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -9176,7 +9447,7 @@
 # name: test_altherma[sensor.sanne_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -9219,7 +9490,7 @@
 # name: test_altherma[sensor.sanne_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9262,7 +9533,7 @@
 # name: test_altherma[sensor.sanne_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9305,7 +9576,7 @@
 # name: test_altherma[sensor.sanne_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9348,7 +9619,7 @@
 # name: test_altherma[sensor.sanne_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9391,7 +9662,7 @@
 # name: test_altherma[sensor.sanne_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9434,7 +9705,7 @@
 # name: test_altherma[sensor.sanne_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9479,7 +9750,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9525,7 +9796,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9571,7 +9842,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9617,7 +9888,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9663,7 +9934,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9709,7 +9980,7 @@
 # name: test_altherma[sensor.sanne_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9756,7 +10027,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -9804,7 +10075,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -9852,7 +10123,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -9897,7 +10168,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -9943,7 +10214,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -9991,7 +10262,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -10039,7 +10310,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -10084,7 +10355,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10127,7 +10398,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10170,7 +10441,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10213,7 +10484,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10256,7 +10527,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10299,7 +10570,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10342,7 +10613,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10385,7 +10656,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10428,7 +10699,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10471,7 +10742,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10514,7 +10785,7 @@
 # name: test_altherma[sensor.werkkamer_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.werkkamer_climatecontrol_outdoor_silent_mode',
@@ -10559,7 +10830,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -10607,7 +10878,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -10652,7 +10923,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10695,7 +10966,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10738,7 +11009,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10781,7 +11052,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10824,7 +11095,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10867,7 +11138,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10910,7 +11181,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10953,7 +11224,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -10996,7 +11267,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -11039,7 +11310,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -11082,7 +11353,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11125,7 +11396,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -11171,7 +11442,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -11216,7 +11487,7 @@
 # name: test_altherma[sensor.werkkamer_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -11259,7 +11530,7 @@
 # name: test_altherma[sensor.werkkamer_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11302,7 +11573,7 @@
 # name: test_altherma[sensor.werkkamer_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11345,7 +11616,7 @@
 # name: test_altherma[sensor.werkkamer_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11388,7 +11659,7 @@
 # name: test_altherma[sensor.werkkamer_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11431,7 +11702,7 @@
 # name: test_altherma[sensor.werkkamer_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11474,7 +11745,7 @@
 # name: test_altherma[sensor.werkkamer_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -11519,7 +11790,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11565,7 +11836,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11611,7 +11882,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11657,7 +11928,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11703,7 +11974,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11749,7 +12020,7 @@
 # name: test_altherma[sensor.werkkamer_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11793,7 +12064,7 @@
 # name: test_altherma[switch.johnny_maaike_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -11836,7 +12107,7 @@
 # name: test_altherma[switch.johnny_maaike_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -11879,7 +12150,7 @@
 # name: test_altherma[switch.linde_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -11922,7 +12193,7 @@
 # name: test_altherma[switch.linde_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -11965,7 +12236,7 @@
 # name: test_altherma[switch.sanne_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -12008,7 +12279,7 @@
 # name: test_altherma[switch.sanne_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -12051,7 +12322,7 @@
 # name: test_altherma[switch.werkkamer_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -12094,7 +12365,7 @@
 # name: test_altherma[switch.werkkamer_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -15451,6 +15722,112 @@
     'state': 'off',
   })
 # ---
+# name: test_climate[select.altherma_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[select.altherma_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_climate[select.johnny_maaike_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.johnny_maaike_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '32db6075-b739-4026-b661-127009254b42_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[select.johnny_maaike_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.johnny_maaike_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
 # name: test_climate[select.linde_climatecontrol_demand_control-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -15502,7 +15879,7 @@
 # name: test_climate[select.linde_climatecontrol_demand_control-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Demand Control',
+      'friendly_name': 'Sanne ClimateControl Demand Control',
       'options': list([
         'off',
         'auto',
@@ -15526,6 +15903,171 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'auto',
+  })
+# ---
+# name: test_climate[select.linde_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.linde_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[select.linde_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.linde_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_climate[select.sanne_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.sanne_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[select.sanne_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.sanne_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_climate[select.werkkamer_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[select.werkkamer_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sanne ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
   })
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_control_mode-entry]
@@ -15561,7 +16103,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_control_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Control Mode',
+      'friendly_name': 'Sanne ClimateControl Control Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -15607,7 +16149,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15655,7 +16197,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15703,7 +16245,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15748,7 +16290,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -15794,7 +16336,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15842,7 +16384,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15890,7 +16432,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -15935,7 +16477,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -15978,7 +16520,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16021,7 +16563,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_is_in_emergency_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Emergency State',
+      'friendly_name': 'Sanne ClimateControl Is In Emergency State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16064,7 +16606,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16107,7 +16649,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Installer State',
+      'friendly_name': 'Sanne ClimateControl Is In Installer State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16150,7 +16692,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16196,7 +16738,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Leaving Water Temperature',
+      'friendly_name': 'Sanne ClimateControl Leaving Water Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -16241,7 +16783,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16287,7 +16829,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -16335,7 +16877,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -16380,7 +16922,7 @@
 # name: test_climate[sensor.altherma_climatecontrol_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Setpoint Mode',
+      'friendly_name': 'Sanne ClimateControl Setpoint Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -16423,7 +16965,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Error Code',
+      'friendly_name': 'Sanne DomesticHotWaterTank Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16469,7 +17011,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -16517,7 +17059,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -16565,7 +17107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde DomesticHotWaterTank Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne DomesticHotWaterTank Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -16610,7 +17152,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Icon Id',
+      'friendly_name': 'Sanne DomesticHotWaterTank Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16653,7 +17195,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is Holiday Mode Active',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16696,7 +17238,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_in_emergency_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Emergency State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Emergency State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16739,7 +17281,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Error State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16782,7 +17324,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Installer State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Installer State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16825,7 +17367,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is In Warning State',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16868,7 +17410,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Is Powerful Mode Active',
+      'friendly_name': 'Sanne DomesticHotWaterTank Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16911,7 +17453,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Name',
+      'friendly_name': 'Sanne DomesticHotWaterTank Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16954,7 +17496,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde DomesticHotWaterTank Setpoint Mode',
+      'friendly_name': 'Sanne DomesticHotWaterTank Setpoint Mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -17000,7 +17542,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde DomesticHotWaterTank Tank Temperature',
+      'friendly_name': 'Sanne DomesticHotWaterTank Tank Temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -17045,7 +17587,7 @@
 # name: test_climate[sensor.altherma_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17088,7 +17630,7 @@
 # name: test_climate[sensor.altherma_gateway_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Icon Id',
+      'friendly_name': 'Sanne Gateway Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17131,7 +17673,7 @@
 # name: test_climate[sensor.altherma_gateway_ip_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ip Address',
+      'friendly_name': 'Sanne Gateway Ip Address',
       'icon': 'mdi:ip-network',
     }),
     'context': <ANY>,
@@ -17174,7 +17716,7 @@
 # name: test_climate[sensor.altherma_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17217,7 +17759,7 @@
 # name: test_climate[sensor.altherma_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17260,7 +17802,7 @@
 # name: test_climate[sensor.altherma_gateway_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Name',
+      'friendly_name': 'Sanne Gateway Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17303,7 +17845,7 @@
 # name: test_climate[sensor.altherma_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -17346,7 +17888,7 @@
 # name: test_climate[sensor.altherma_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -17389,7 +17931,7 @@
 # name: test_climate[sensor.altherma_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -17435,7 +17977,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -17480,7 +18022,7 @@
 # name: test_climate[sensor.altherma_indoorunithydro_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnitHydro Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17523,7 +18065,7 @@
 # name: test_climate[sensor.altherma_indoorunithydro_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Icon Id',
+      'friendly_name': 'Sanne IndoorUnitHydro Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17566,7 +18108,7 @@
 # name: test_climate[sensor.altherma_indoorunithydro_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Model Info',
+      'friendly_name': 'Sanne IndoorUnitHydro Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17609,7 +18151,7 @@
 # name: test_climate[sensor.altherma_indoorunithydro_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Name',
+      'friendly_name': 'Sanne IndoorUnitHydro Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17652,7 +18194,7 @@
 # name: test_climate[sensor.altherma_indoorunithydro_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnitHydro Software Version',
+      'friendly_name': 'Sanne IndoorUnitHydro Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17695,7 +18237,7 @@
 # name: test_climate[sensor.altherma_outdoorunit_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Icon Id',
+      'friendly_name': 'Sanne OutdoorUnit Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17738,7 +18280,7 @@
 # name: test_climate[sensor.altherma_outdoorunit_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Model Info',
+      'friendly_name': 'Sanne OutdoorUnit Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17781,7 +18323,7 @@
 # name: test_climate[sensor.altherma_outdoorunit_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Name',
+      'friendly_name': 'Sanne OutdoorUnit Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17824,7 +18366,7 @@
 # name: test_climate[sensor.altherma_outdoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Software Version',
+      'friendly_name': 'Sanne OutdoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17869,7 +18411,7 @@
 # name: test_climate[sensor.altherma_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -17915,7 +18457,7 @@
 # name: test_climate[sensor.altherma_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -17961,7 +18503,7 @@
 # name: test_climate[sensor.altherma_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -18007,7 +18549,7 @@
 # name: test_climate[sensor.altherma_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -18053,7 +18595,7 @@
 # name: test_climate[sensor.altherma_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -18099,7 +18641,7 @@
 # name: test_climate[sensor.altherma_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -18143,7 +18685,7 @@
 # name: test_climate[sensor.altherma_userinterface_date_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Date Time',
+      'friendly_name': 'Sanne UserInterface Date Time',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18186,7 +18728,7 @@
 # name: test_climate[sensor.altherma_userinterface_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Firmware Version',
+      'friendly_name': 'Sanne UserInterface Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18229,7 +18771,7 @@
 # name: test_climate[sensor.altherma_userinterface_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Icon Id',
+      'friendly_name': 'Sanne UserInterface Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18272,7 +18814,7 @@
 # name: test_climate[sensor.altherma_userinterface_micon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Micon Id',
+      'friendly_name': 'Sanne UserInterface Micon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18315,7 +18857,7 @@
 # name: test_climate[sensor.altherma_userinterface_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Name',
+      'friendly_name': 'Sanne UserInterface Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18358,7 +18900,7 @@
 # name: test_climate[sensor.altherma_userinterface_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde UserInterface Software Version',
+      'friendly_name': 'Sanne UserInterface Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18404,7 +18946,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18452,7 +18994,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18500,7 +19042,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18545,7 +19087,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18591,7 +19133,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18639,7 +19181,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18687,7 +19229,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -18732,7 +19274,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18775,7 +19317,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18818,7 +19360,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18861,7 +19403,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18904,7 +19446,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18947,7 +19489,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -18990,7 +19532,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19033,7 +19575,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19076,7 +19618,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19119,7 +19661,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19162,7 +19704,7 @@
 # name: test_climate[sensor.johnny_maaike_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.johnny_maaike_climatecontrol_outdoor_silent_mode',
@@ -19207,7 +19749,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -19255,7 +19797,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -19300,7 +19842,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19343,7 +19885,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19386,7 +19928,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19429,7 +19971,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19472,7 +20014,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19515,7 +20057,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19558,7 +20100,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19601,7 +20143,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19644,7 +20186,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -19687,7 +20229,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -19730,7 +20272,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19773,7 +20315,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -19819,7 +20361,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -19864,7 +20406,7 @@
 # name: test_climate[sensor.johnny_maaike_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -19907,7 +20449,7 @@
 # name: test_climate[sensor.johnny_maaike_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19950,7 +20492,7 @@
 # name: test_climate[sensor.johnny_maaike_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -19993,7 +20535,7 @@
 # name: test_climate[sensor.johnny_maaike_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20036,7 +20578,7 @@
 # name: test_climate[sensor.johnny_maaike_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20079,7 +20621,7 @@
 # name: test_climate[sensor.johnny_maaike_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20122,7 +20664,7 @@
 # name: test_climate[sensor.johnny_maaike_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20167,7 +20709,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20213,7 +20755,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20259,7 +20801,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20305,7 +20847,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20351,7 +20893,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20397,7 +20939,7 @@
 # name: test_climate[sensor.johnny_maaike_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20444,7 +20986,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20492,7 +21034,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20540,7 +21082,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20585,7 +21127,7 @@
 # name: test_climate[sensor.linde_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20631,7 +21173,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20679,7 +21221,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20727,7 +21269,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -20772,7 +21314,7 @@
 # name: test_climate[sensor.linde_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20815,7 +21357,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20858,7 +21400,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20901,7 +21443,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20944,7 +21486,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -20987,7 +21529,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21030,7 +21572,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21073,7 +21615,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21116,7 +21658,7 @@
 # name: test_climate[sensor.linde_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21159,7 +21701,7 @@
 # name: test_climate[sensor.linde_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21202,7 +21744,7 @@
 # name: test_climate[sensor.linde_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.linde_climatecontrol_outdoor_silent_mode',
@@ -21247,7 +21789,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -21295,7 +21837,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -21340,7 +21882,7 @@
 # name: test_climate[sensor.linde_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21383,7 +21925,7 @@
 # name: test_climate[sensor.linde_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21426,7 +21968,7 @@
 # name: test_climate[sensor.linde_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21469,7 +22011,7 @@
 # name: test_climate[sensor.linde_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21512,7 +22054,7 @@
 # name: test_climate[sensor.linde_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21555,7 +22097,7 @@
 # name: test_climate[sensor.linde_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21598,7 +22140,7 @@
 # name: test_climate[sensor.linde_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21641,7 +22183,7 @@
 # name: test_climate[sensor.linde_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21684,7 +22226,7 @@
 # name: test_climate[sensor.linde_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -21727,7 +22269,7 @@
 # name: test_climate[sensor.linde_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -21770,7 +22312,7 @@
 # name: test_climate[sensor.linde_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21813,7 +22355,7 @@
 # name: test_climate[sensor.linde_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -21859,7 +22401,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -21904,7 +22446,7 @@
 # name: test_climate[sensor.linde_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -21947,7 +22489,7 @@
 # name: test_climate[sensor.linde_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -21990,7 +22532,7 @@
 # name: test_climate[sensor.linde_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22033,7 +22575,7 @@
 # name: test_climate[sensor.linde_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22076,7 +22618,7 @@
 # name: test_climate[sensor.linde_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22119,7 +22661,7 @@
 # name: test_climate[sensor.linde_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22162,7 +22704,7 @@
 # name: test_climate[sensor.linde_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22207,7 +22749,7 @@
 # name: test_climate[sensor.linde_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22253,7 +22795,7 @@
 # name: test_climate[sensor.linde_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22299,7 +22841,7 @@
 # name: test_climate[sensor.linde_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22345,7 +22887,7 @@
 # name: test_climate[sensor.linde_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22391,7 +22933,7 @@
 # name: test_climate[sensor.linde_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22437,7 +22979,7 @@
 # name: test_climate[sensor.linde_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -22484,7 +23026,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22532,7 +23074,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22580,7 +23122,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22625,7 +23167,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22671,7 +23213,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22719,7 +23261,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22767,7 +23309,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22812,7 +23354,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22855,7 +23397,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22898,7 +23440,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22941,7 +23483,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22984,7 +23526,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23027,7 +23569,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23070,7 +23612,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23113,7 +23655,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23156,7 +23698,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23199,7 +23741,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23242,7 +23784,7 @@
 # name: test_climate[sensor.sanne_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.sanne_climatecontrol_outdoor_silent_mode',
@@ -23287,7 +23829,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -23335,7 +23877,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -23380,7 +23922,7 @@
 # name: test_climate[sensor.sanne_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23423,7 +23965,7 @@
 # name: test_climate[sensor.sanne_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23466,7 +24008,7 @@
 # name: test_climate[sensor.sanne_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23509,7 +24051,7 @@
 # name: test_climate[sensor.sanne_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23552,7 +24094,7 @@
 # name: test_climate[sensor.sanne_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23595,7 +24137,7 @@
 # name: test_climate[sensor.sanne_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23638,7 +24180,7 @@
 # name: test_climate[sensor.sanne_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23681,7 +24223,7 @@
 # name: test_climate[sensor.sanne_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23724,7 +24266,7 @@
 # name: test_climate[sensor.sanne_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -23767,7 +24309,7 @@
 # name: test_climate[sensor.sanne_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -23810,7 +24352,7 @@
 # name: test_climate[sensor.sanne_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -23853,7 +24395,7 @@
 # name: test_climate[sensor.sanne_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -23899,7 +24441,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -23944,7 +24486,7 @@
 # name: test_climate[sensor.sanne_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -23987,7 +24529,7 @@
 # name: test_climate[sensor.sanne_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24030,7 +24572,7 @@
 # name: test_climate[sensor.sanne_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24073,7 +24615,7 @@
 # name: test_climate[sensor.sanne_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24116,7 +24658,7 @@
 # name: test_climate[sensor.sanne_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24159,7 +24701,7 @@
 # name: test_climate[sensor.sanne_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24202,7 +24744,7 @@
 # name: test_climate[sensor.sanne_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24247,7 +24789,7 @@
 # name: test_climate[sensor.sanne_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24293,7 +24835,7 @@
 # name: test_climate[sensor.sanne_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24339,7 +24881,7 @@
 # name: test_climate[sensor.sanne_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24385,7 +24927,7 @@
 # name: test_climate[sensor.sanne_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24431,7 +24973,7 @@
 # name: test_climate[sensor.sanne_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24477,7 +25019,7 @@
 # name: test_climate[sensor.sanne_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24524,7 +25066,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Daily Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24572,7 +25114,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Weekly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24620,7 +25162,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Cooling Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Cooling Yearly Electrical Consumption',
       'icon': 'mdi:snowflake',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24665,7 +25207,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Error Code',
+      'friendly_name': 'Sanne ClimateControl Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24711,7 +25253,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Daily Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Daily Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24759,7 +25301,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Weekly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Weekly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24807,7 +25349,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Linde ClimateControl Heating Yearly Electrical Consumption',
+      'friendly_name': 'Sanne ClimateControl Heating Yearly Electrical Consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -24852,7 +25394,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_icon_id-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Icon Id',
+      'friendly_name': 'Sanne ClimateControl Icon Id',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24895,7 +25437,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_cool_heat_master-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Cool Heat Master',
+      'friendly_name': 'Sanne ClimateControl Is Cool Heat Master',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24938,7 +25480,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Holiday Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Holiday Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -24981,7 +25523,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Caution State',
+      'friendly_name': 'Sanne ClimateControl Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25024,7 +25566,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Error State',
+      'friendly_name': 'Sanne ClimateControl Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25067,7 +25609,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_in_mode_conflict-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Mode Conflict',
+      'friendly_name': 'Sanne ClimateControl Is In Mode Conflict',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25110,7 +25652,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is In Warning State',
+      'friendly_name': 'Sanne ClimateControl Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25153,7 +25695,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_lock_function_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Lock Function Enabled',
+      'friendly_name': 'Sanne ClimateControl Is Lock Function Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25196,7 +25738,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Is Powerful Mode Active',
+      'friendly_name': 'Sanne ClimateControl Is Powerful Mode Active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25239,7 +25781,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Name',
+      'friendly_name': 'Sanne ClimateControl Name',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25282,7 +25824,7 @@
 # name: test_climate[sensor.werkkamer_climatecontrol_outdoor_silent_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Outdoor Silent Mode',
+      'friendly_name': 'Sanne ClimateControl Outdoor Silent Mode',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.werkkamer_climatecontrol_outdoor_silent_mode',
@@ -25327,7 +25869,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Outdoor Temperature',
+      'friendly_name': 'Sanne ClimateControl Outdoor Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -25375,7 +25917,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Linde ClimateControl Room Temperature',
+      'friendly_name': 'Sanne ClimateControl Room Temperature',
       'icon': '',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -25420,7 +25962,7 @@
 # name: test_climate[sensor.werkkamer_gateway_daylight_saving_time_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Daylight Saving Time Enabled',
+      'friendly_name': 'Sanne Gateway Daylight Saving Time Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25463,7 +26005,7 @@
 # name: test_climate[sensor.werkkamer_gateway_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Error Code',
+      'friendly_name': 'Sanne Gateway Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25506,7 +26048,7 @@
 # name: test_climate[sensor.werkkamer_gateway_firmware_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Firmware Version',
+      'friendly_name': 'Sanne Gateway Firmware Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25549,7 +26091,7 @@
 # name: test_climate[sensor.werkkamer_gateway_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Is In Error State',
+      'friendly_name': 'Sanne Gateway Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25592,7 +26134,7 @@
 # name: test_climate[sensor.werkkamer_gateway_led_enabled-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Led Enabled',
+      'friendly_name': 'Sanne Gateway Led Enabled',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25635,7 +26177,7 @@
 # name: test_climate[sensor.werkkamer_gateway_mac_address-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Mac Address',
+      'friendly_name': 'Sanne Gateway Mac Address',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25678,7 +26220,7 @@
 # name: test_climate[sensor.werkkamer_gateway_model_info-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Model Info',
+      'friendly_name': 'Sanne Gateway Model Info',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25721,7 +26263,7 @@
 # name: test_climate[sensor.werkkamer_gateway_region_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Region Code',
+      'friendly_name': 'Sanne Gateway Region Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25764,7 +26306,7 @@
 # name: test_climate[sensor.werkkamer_gateway_serial_number-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Serial Number',
+      'friendly_name': 'Sanne Gateway Serial Number',
       'icon': 'mdi:numeric',
     }),
     'context': <ANY>,
@@ -25807,7 +26349,7 @@
 # name: test_climate[sensor.werkkamer_gateway_ssid-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Ssid',
+      'friendly_name': 'Sanne Gateway Ssid',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -25850,7 +26392,7 @@
 # name: test_climate[sensor.werkkamer_gateway_time_zone-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Time Zone',
+      'friendly_name': 'Sanne Gateway Time Zone',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -25893,7 +26435,7 @@
 # name: test_climate[sensor.werkkamer_gateway_wifi_connection_s_s_i_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway Wifi Connection S S I D',
+      'friendly_name': 'Sanne Gateway Wifi Connection S S I D',
       'icon': 'mdi:access-point-network',
     }),
     'context': <ANY>,
@@ -25939,7 +26481,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'signal_strength',
-      'friendly_name': 'Linde Gateway Wifi Connection Strength',
+      'friendly_name': 'Sanne Gateway Wifi Connection Strength',
       'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'dBm',
@@ -25984,7 +26526,7 @@
 # name: test_climate[sensor.werkkamer_indoorunit_dry_keep_setting-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Dry Keep Setting',
+      'friendly_name': 'Sanne IndoorUnit Dry Keep Setting',
       'icon': 'mdi:water-percent',
     }),
     'context': <ANY>,
@@ -26027,7 +26569,7 @@
 # name: test_climate[sensor.werkkamer_indoorunit_eeprom_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Eeprom Version',
+      'friendly_name': 'Sanne IndoorUnit Eeprom Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26070,7 +26612,7 @@
 # name: test_climate[sensor.werkkamer_indoorunit_software_version-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde IndoorUnit Software Version',
+      'friendly_name': 'Sanne IndoorUnit Software Version',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26113,7 +26655,7 @@
 # name: test_climate[sensor.werkkamer_outdoorunit_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Error Code',
+      'friendly_name': 'Sanne OutdoorUnit Error Code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26156,7 +26698,7 @@
 # name: test_climate[sensor.werkkamer_outdoorunit_is_in_caution_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Caution State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Caution State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26199,7 +26741,7 @@
 # name: test_climate[sensor.werkkamer_outdoorunit_is_in_error_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Error State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Error State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26242,7 +26784,7 @@
 # name: test_climate[sensor.werkkamer_outdoorunit_is_in_warning_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde OutdoorUnit Is In Warning State',
+      'friendly_name': 'Sanne OutdoorUnit Is In Warning State',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -26287,7 +26829,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit day',
+      'friendly_name': 'Sanne RateLimit day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26333,7 +26875,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_minute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit minute',
+      'friendly_name': 'Sanne RateLimit minute',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26379,7 +26921,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_ratelimit_reset-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit ratelimit_reset',
+      'friendly_name': 'Sanne RateLimit ratelimit_reset',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26425,7 +26967,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_day',
+      'friendly_name': 'Sanne RateLimit remaining_day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26471,7 +27013,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_remaining_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit remaining_minutes',
+      'friendly_name': 'Sanne RateLimit remaining_minutes',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26517,7 +27059,7 @@
 # name: test_climate[sensor.werkkamer_ratelimit_retry_after-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde RateLimit retry_after',
+      'friendly_name': 'Sanne RateLimit retry_after',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -26561,7 +27103,7 @@
 # name: test_climate[switch.johnny_maaike_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -26604,7 +27146,7 @@
 # name: test_climate[switch.johnny_maaike_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -26647,7 +27189,7 @@
 # name: test_climate[switch.linde_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -26690,7 +27232,7 @@
 # name: test_climate[switch.linde_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -26733,7 +27275,7 @@
 # name: test_climate[switch.sanne_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -26776,7 +27318,7 @@
 # name: test_climate[switch.sanne_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -26819,7 +27361,7 @@
 # name: test_climate[switch.werkkamer_climatecontrol_econo_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Econo Mode',
+      'friendly_name': 'Sanne ClimateControl Econo Mode',
       'icon': 'mdi:leaf',
     }),
     'context': <ANY>,
@@ -26862,7 +27404,7 @@
 # name: test_climate[switch.werkkamer_climatecontrol_streamer_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde ClimateControl Streamer Mode',
+      'friendly_name': 'Sanne ClimateControl Streamer Mode',
       'icon': 'hass:air-filter',
     }),
     'context': <ANY>,
@@ -27049,6 +27591,57 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_climate_fixedfanmode[select.werkkamer_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_fixedfanmode[select.werkkamer_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Werkkamer ClimateControl Schedule',
+      'options': list([
+        '0',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.werkkamer_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
   })
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_cooling_daily_electrical_consumption-entry]
@@ -28833,6 +29426,61 @@
     'state': 'auto',
   })
 # ---
+# name: test_climate_floorheatingairflow[select.laurens_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.laurens_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '71f33ee1-a82d-4f08-8f61-bf25fd872731_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_floorheatingairflow[select.laurens_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Laurens ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.laurens_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
 # name: test_climate_floorheatingairflow[select.woonkamer_airco_climatecontrol_demand_control-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -28908,6 +29556,61 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'auto',
+  })
+# ---
+# name: test_climate_floorheatingairflow[select.woonkamer_airco_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.woonkamer_airco_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '27920256-e0af-4780-8f5f-1f88d8fdf0ba_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_floorheatingairflow[select.woonkamer_airco_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Woonkamer airco ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.woonkamer_airco_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
   })
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_cooling_daily_electrical_consumption-entry]
@@ -66530,6 +67233,112 @@
     'state': 'heat',
   })
 # ---
+# name: test_mc80z[select.climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_mc80z[select.climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'ClimateControl Schedule',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_mc80z[select.vloerverwarming_domestichotwatertank_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.vloerverwarming_domestichotwatertank_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'DomesticHotWaterTank Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4e19a975-b0e4-4ae1-8439-c037e7d0df01_domesticHotWaterTank_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_mc80z[select.vloerverwarming_domestichotwatertank_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Vloerverwarming DomesticHotWaterTank Schedule',
+      'options': list([
+        'User defined',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.vloerverwarming_domestichotwatertank_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'User defined',
+  })
+# ---
 # name: test_mc80z[sensor.climatecontrol_air_purification_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -70368,6 +71177,61 @@
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'heat',
+  })
+# ---
+# name: test_water_heater[select.altherma_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'User defined 1',
+        'User defined 2',
+        'User defined 3',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_water_heater[select.altherma_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Altherma ClimateControl Schedule',
+      'options': list([
+        'User defined 1',
+        'User defined 2',
+        'User defined 3',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.altherma_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
   })
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_control_mode-entry]


### PR DESCRIPTION
… schedule is set. The strings shown are the names as returned from the Daikin cloud. No support yet to change the schedule, only showing whether a schedule is define and selected

    * custom_components/daikin_onecta/select.py:
    * tests/snapshots/test_init.ambr:

Implements part of #115 