### PR TITLE
Fix for device which is set to dry but doesn't provide fanspeed control

### DIFF
--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -424,16 +424,17 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
             operation_mode = cc["operationMode"]["value"]
             operationmodedict = fanControl["value"]["operationModes"].get(operation_mode)
             if operationmodedict is not None:
-                fan_speed = operationmodedict["fanSpeed"]
-                mode = fan_speed["currentMode"]["value"]
-                if mode == FANMODE_FIXED:
-                    fsm = fan_speed.get("modes")
-                    if fsm is not None:
-                        _LOGGER.info("FSM %s", fsm)
-                        fixedModes = fsm[mode]
-                        fan_mode = str(fixedModes["value"])
-                else:
-                    fan_mode = mode
+                fan_speed = operationmodedict.get("fanSpeed")
+                if fan_speed is not None:
+                    mode = fan_speed["currentMode"]["value"]
+                    if mode == FANMODE_FIXED:
+                        fsm = fan_speed.get("modes")
+                        if fsm is not None:
+                            _LOGGER.info("FSM %s", fsm)
+                            fixedModes = fsm[mode]
+                            fan_mode = str(fixedModes["value"])
+                    else:
+                        fan_mode = mode
 
         return fan_mode
 
@@ -446,22 +447,23 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
             operation_mode = cc["operationMode"]["value"]
             operationmodedict = fan_control["value"]["operationModes"].get(operation_mode)
             if operationmodedict is not None:
-                fan_speed = operationmodedict["fanSpeed"]
-                _LOGGER.info("Found fanspeed %s", fan_speed)
-                for c in fan_speed["currentMode"]["values"]:
-                    _LOGGER.info("Device '%s' found fan mode %s", self._device.name, c)
-                    if c == FANMODE_FIXED:
-                        fsm = fan_speed.get("modes")
-                        if fsm is not None:
-                            _LOGGER.info("Device '%s' found fixed %s", self._device.name, fsm)
-                            fixedModes = fsm[c]
-                            min_val = int(fixedModes["minValue"])
-                            max_val = int(fixedModes["maxValue"])
-                            step_value = int(fixedModes["stepValue"])
-                            for val in range(min_val, max_val + 1, step_value):
-                                fan_modes.append(str(val))
-                    else:
-                        fan_modes.append(c)
+                fan_speed = operationmodedict.get("fanSpeed")
+                if fan_speed is not None:
+                    _LOGGER.info("Found fanspeed %s", fan_speed)
+                    for c in fan_speed["currentMode"]["values"]:
+                        _LOGGER.info("Device '%s' found fan mode %s", self._device.name, c)
+                        if c == FANMODE_FIXED:
+                            fsm = fan_speed.get("modes")
+                            if fsm is not None:
+                                _LOGGER.info("Device '%s' found fixed %s", self._device.name, fsm)
+                                fixedModes = fsm[c]
+                                min_val = int(fixedModes["minValue"])
+                                max_val = int(fixedModes["maxValue"])
+                                step_value = int(fixedModes["stepValue"])
+                                for val in range(min_val, max_val + 1, step_value):
+                                    fan_modes.append(str(val))
+                        else:
+                            fan_modes.append(c)
 
         return fan_modes
 

--- a/tests/fixtures/dry2.json
+++ b/tests/fixtures/dry2.json
@@ -1,0 +1,2913 @@
+[
+      {
+        "_id": "1b4e05a4-466d-41d8-b90e-19dded548684",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.61"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a5:24"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Master Bathroom"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 25.7,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 21,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA20A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514194",
+        "timestamp": "2024-04-17T08:04:40.236Z",
+        "id": "1b4e05a4-466d-41d8-b90e-19dded548684"
+      },
+      {
+        "_id": "1bcc6300-47e8-46c8-9ca8-79b4e649e145",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.56"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a1:f0"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Lounge"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "on"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 23.9,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 23,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA32A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514120",
+        "timestamp": "2024-04-17T08:11:29.316Z",
+        "id": "1bcc6300-47e8-46c8-9ca8-79b4e649e145"
+      },
+      {
+        "_id": "4c60a395-f659-47d6-9a4b-be9aae836761",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.62"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a0:ca"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "heating": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    },
+                    "fanDirection": {
+                      "vertical": {
+                        "currentMode": {
+                          "value": "fixed",
+                          "settable": true,
+                          "values": [
+                            "swing",
+                            "fixed"
+                          ]
+                        },
+                        "modes": {
+                          "fixed": {
+                            "value": 5,
+                            "stepValue": 1,
+                            "minValue": 1,
+                            "maxValue": 5,
+                            "settable": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "fixed",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 3,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    },
+                    "fanDirection": {
+                      "vertical": {
+                        "currentMode": {
+                          "value": "fixed",
+                          "settable": true,
+                          "values": [
+                            "swing",
+                            "fixed"
+                          ]
+                        },
+                        "modes": {
+                          "fixed": {
+                            "value": 2,
+                            "stepValue": 1,
+                            "minValue": 1,
+                            "maxValue": 5,
+                            "settable": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "dry": {
+                    "fanDirection": {
+                      "vertical": {
+                        "currentMode": {
+                          "value": "fixed",
+                          "settable": true,
+                          "values": [
+                            "swing",
+                            "fixed"
+                          ]
+                        },
+                        "modes": {
+                          "fixed": {
+                            "value": 2,
+                            "stepValue": 1,
+                            "minValue": 1,
+                            "maxValue": 5,
+                            "settable": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "fixed",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 3,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    },
+                    "fanDirection": {
+                      "vertical": {
+                        "currentMode": {
+                          "value": "fixed",
+                          "settable": true,
+                          "values": [
+                            "swing",
+                            "fixed"
+                          ]
+                        },
+                        "modes": {
+                          "fixed": {
+                            "value": 2,
+                            "stepValue": 1,
+                            "minValue": 1,
+                            "maxValue": 5,
+                            "settable": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Bedroom 3"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "heating",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "fanOnly",
+                            "heating",
+                            "cooling",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 19.2,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "heating": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 22,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  },
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 22,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXAA15AUV1B"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "18013303"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514214",
+        "timestamp": "2024-04-17T08:12:52.890Z",
+        "id": "4c60a395-f659-47d6-9a4b-be9aae836761"
+      },
+      {
+        "_id": "72b407b4-4e6f-47e2-814f-ee36d1548858",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.55"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a0:bc"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Kitchen"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 24.8,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 22,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA32A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514119",
+        "timestamp": "2024-04-17T08:10:56.628Z",
+        "id": "72b407b4-4e6f-47e2-814f-ee36d1548858"
+      },
+      {
+        "_id": "7bd36d96-73b3-44a1-8642-f3650e9cc732",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.57"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:9a:ec"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 3,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 3,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Bedroom 1"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 23.9,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 22,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA20A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514165",
+        "timestamp": "2024-04-17T08:12:25.501Z",
+        "id": "7bd36d96-73b3-44a1-8642-f3650e9cc732"
+      },
+      {
+        "_id": "c7d4957f-2b0a-468f-adbc-06d150d9af39",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.59"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a0:86"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Master Bedroom"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 25.1,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 22,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA25A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+        "type": "dx4",
+        "embeddedId": "1514183",
+        "timestamp": "2024-04-17T07:53:31.619Z",
+        "id": "c7d4957f-2b0a-468f-adbc-06d150d9af39"
+      },
+      {
+        "_id": "df4648e9-d40b-4242-b9fe-e5d0f6451a6b",
+        "deviceModel": "dx4",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "errorCode": {
+              "settable": false,
+              "value": ""
+            },
+            "firmwareVersion": {
+              "settable": false,
+              "value": "1_30_0"
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "value": true
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.87.58"
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "dc:fe:23:bb:a2:e0"
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069C5x"
+            }
+          },
+          {
+            "embeddedId": "climateControl",
+            "managementPointType": "climateControl",
+            "managementPointSubType": "mainZone",
+            "managementPointCategory": "primary",
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "fanControl": {
+              "ref": "#fanControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  },
+                  "fanOnly": {
+                    "fanSpeed": {
+                      "currentMode": {
+                        "value": "auto",
+                        "settable": true,
+                        "values": [
+                          "auto",
+                          "fixed"
+                        ]
+                      },
+                      "modes": {
+                        "fixed": {
+                          "value": 1,
+                          "stepValue": 1,
+                          "minValue": 1,
+                          "maxValue": 3,
+                          "settable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "holidayMode": {
+              "ref": "#holidayMode",
+              "settable": true,
+              "value": {
+                "enabled": false
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "maxLength": 20,
+              "value": "Bedroom 2"
+            },
+            "onOffMode": {
+              "settable": true,
+              "values": [
+                "on",
+                "off"
+              ],
+              "value": "off"
+            },
+            "operationMode": {
+              "settable": true,
+              "value": "dry",
+              "values": [
+                "fanOnly",
+                "cooling",
+                "dry"
+              ]
+            },
+            "schedule": {
+              "ref": "#schedule",
+              "settable": true,
+              "value": {
+                "currentMode": {
+                  "value": "any",
+                  "settable": true,
+                  "values": [
+                    "any"
+                  ]
+                },
+                "nextAction": {},
+                "modes": {
+                  "any": {
+                    "currentSchedule": {
+                      "value": "0",
+                      "settable": true,
+                      "values": [
+                        "0",
+                        "1",
+                        "2"
+                      ]
+                    },
+                    "enabled": {
+                      "value": false,
+                      "settable": true
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:01:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "operationMode": {
+                          "settable": false,
+                          "values": [
+                            "heating",
+                            "cooling",
+                            "fanOnly",
+                            "dry",
+                            "off"
+                          ]
+                        },
+                        "roomTemperature": {
+                          "heating": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          },
+                          "cooling": {
+                            "settable": false,
+                            "stepValue": 0.5,
+                            "minValue": 16,
+                            "maxValue": 32
+                          }
+                        },
+                        "fanSpeed": {
+                          "heating": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "cooling": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          },
+                          "fanOnly": {
+                            "currentMode": {
+                              "settable": false,
+                              "values": [
+                                "auto",
+                                "fixed"
+                              ]
+                            },
+                            "modes": {
+                              "fixed": {
+                                "stepValue": 1,
+                                "minValue": 1,
+                                "maxValue": 3,
+                                "settable": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "0": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "1": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      },
+                      "2": {
+                        "name": {
+                          "maxLength": 32,
+                          "settable": false,
+                          "value": ""
+                        },
+                        "meta": {
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ],
+                          "isReadOnly": false
+                        },
+                        "actions": {},
+                        "settable": false
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "ref": "#sensoryData",
+              "settable": false,
+              "value": {
+                "roomTemperature": {
+                  "settable": false,
+                  "unit": "\u00b0C",
+                  "value": 24.7,
+                  "stepValue": 0.01,
+                  "minValue": -43.05,
+                  "maxValue": 127
+                }
+              }
+            },
+            "temperatureControl": {
+              "ref": "#temperatureControl",
+              "settable": true,
+              "value": {
+                "operationModes": {
+                  "cooling": {
+                    "setpoints": {
+                      "roomTemperature": {
+                        "settable": true,
+                        "value": 21,
+                        "unit": "\u00b0C",
+                        "stepValue": 0.1,
+                        "minValue": 16,
+                        "maxValue": 32
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnit",
+            "managementPointType": "indoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "FXSA20A2VEB"
+            },
+            "softwareVersion": {
+              "settable": false,
+              "value": "19000A03"
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "value": "RXYSA6A7V1B"
+            },
+            "errorCode": {
+              "settable": false,
+              "value": "-"
+            },
+            "isInErrorState": {
+              "settable": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "value": false
+            },
+            "isInCautionState": {
+              "settable": false,
+              "value": false
+            }
+          }
+        ],
+       "type": "dx4",
+        "embeddedId": "1514176",
+        "timestamp": "2024-04-17T08:12:47.563Z",
+        "id": "df4648e9-d40b-4242-b9fe-e5d0f6451a6b"
+      }
+    ]

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -45798,6 +45798,9232 @@
     'state': 'off',
   })
 # ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 1 OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_1_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 2 OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_2_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Bedroom 3 OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_3_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Kitchen OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Lounge OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bathroom OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bathroom_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is Holiday Mode Active',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isholidaymodeactive',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_isHolidayModeActive',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom ClimateControl Is Holiday Mode Active',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isincautionstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom ClimateControl Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinerrorstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom ClimateControl Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_isinwarningstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom ClimateControl Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_climatecontrol_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_gateway_is_firmware_update_supported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_gateway_is_firmware_update_supported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is Firmware Update Supported',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isfirmwareupdatesupported',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_isFirmwareUpdateSupported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_gateway_is_firmware_update_supported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Is Firmware Update Supported',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_gateway_is_firmware_update_supported',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_gateway_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_gateway_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_isinerrorstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_gateway_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom Gateway Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_gateway_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_caution_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_caution_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Caution State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isincautionstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_None_isInCautionState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_caution_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom OutdoorUnit Is In Caution State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_caution_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_error_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_error_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Error State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinerrorstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_None_isInErrorState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_error_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom OutdoorUnit Is In Error State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_error_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_warning_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_warning_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Is In Warning State',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_isinwarningstate',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_None_isInWarningState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_warning_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Master Bedroom OutdoorUnit Is In Warning State',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.master_bedroom_outdoorunit_is_in_warning_state',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.bedroom_1_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.bedroom_1_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bedroom 1 Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.bedroom_1_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 23.9,
+      'friendly_name': 'Bedroom 1 Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bedroom_1_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.bedroom_2_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.bedroom_2_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bedroom 2 Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.bedroom_2_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 24.7,
+      'friendly_name': 'Bedroom 2 Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bedroom_2_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.bedroom_3_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'swing_modes': list([
+        'off',
+        'vertical',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.bedroom_3_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bedroom 3 Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 48>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.bedroom_3_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 19.2,
+      'friendly_name': 'Bedroom 3 Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 48>,
+      'swing_mode': 'off',
+      'swing_modes': list([
+        'off',
+        'vertical',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.bedroom_3_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.kitchen_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.kitchen_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Kitchen Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.kitchen_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 24.8,
+      'friendly_name': 'Kitchen Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.kitchen_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.lounge_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.lounge_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lounge Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.lounge_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 23.9,
+      'friendly_name': 'Lounge Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.lounge_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dry',
+  })
+# ---
+# name: test_dry2[climate.master_bathroom_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.master_bathroom_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Master Bathroom Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.master_bathroom_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 25.7,
+      'friendly_name': 'Master Bathroom Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.master_bathroom_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[climate.master_bedroom_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.master_bedroom_room_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Master Bedroom Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': <ClimateEntityFeature: 16>,
+    'translation_key': 'daikin_onecta',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_roomTemperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[climate.master_bedroom_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 25.1,
+      'friendly_name': 'Master Bedroom Room Temperature',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.DRY: 'dry'>,
+      ]),
+      'max_temp': None,
+      'min_temp': None,
+      'preset_mode': 'none',
+      'preset_modes': list([
+        'away',
+        'none',
+      ]),
+      'supported_features': <ClimateEntityFeature: 16>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.master_bedroom_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.bedroom_1_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.bedroom_1_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.bedroom_1_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.bedroom_1_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.bedroom_2_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.bedroom_2_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.bedroom_2_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.bedroom_2_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.bedroom_3_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.bedroom_3_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.bedroom_3_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.bedroom_3_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.kitchen_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.kitchen_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.kitchen_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.kitchen_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.lounge_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.lounge_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.lounge_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.lounge_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.master_bathroom_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.master_bathroom_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.master_bathroom_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.master_bathroom_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[select.master_bedroom_climatecontrol_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.master_bedroom_climatecontrol_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:calendar-clock',
+    'original_name': 'ClimateControl Schedule',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[select.master_bedroom_climatecontrol_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom ClimateControl Schedule',
+      'icon': 'mdi:calendar-clock',
+      'options': list([
+        '0',
+        '1',
+        '2',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.master_bedroom_climatecontrol_schedule',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Bedroom 1',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Bedroom 1 ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '23.9',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.57',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:9a:ec',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA20A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_1_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 1 RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_1_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Bedroom 2',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Bedroom 2 ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.7',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.58',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a2:e0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA20A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_2_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 2 RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_2_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Bedroom 3',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Bedroom 3 ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19.2',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.62',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a0:ca',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXAA15AUV1B',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '18013303',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.bedroom_3_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bedroom 3 RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_3_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Kitchen',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Kitchen ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24.8',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.55',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a0:bc',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA32A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.kitchen_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Lounge',
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.lounge_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.lounge_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Lounge ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '23.9',
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.56',
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a1:f0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.lounge_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA32A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.lounge_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.lounge_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.lounge_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.lounge_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.lounge_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Lounge RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.lounge_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Master Bathroom',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Master Bathroom ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.7',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.61',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a5:24',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA20A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bathroom_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bathroom RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bathroom_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_errorcode',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom ClimateControl Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'ClimateControl Name',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_name',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_None_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom ClimateControl Name',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_name',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Master Bedroom',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': '',
+    'original_name': 'ClimateControl Room Temperature',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'climatecontrol_roomtemperature',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_climateControl_sensoryData_roomTemperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_climatecontrol_room_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Master Bedroom ClimateControl Room Temperature',
+      'icon': '',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_climatecontrol_room_temperature',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.1',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_gateway_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_errorcode',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_gateway_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_firmware_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_gateway_firmware_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Firmware Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_firmwareversion',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_firmwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_firmware_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Firmware Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_gateway_firmware_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1_30_0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_ip_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_gateway_ip_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:ip-network',
+    'original_name': 'Gateway Ip Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_ipaddress',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_ipAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_ip_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Ip Address',
+      'icon': 'mdi:ip-network',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_gateway_ip_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '192.168.87.59',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_mac_address-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_gateway_mac_address',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Mac Address',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_macaddress',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_macAddress',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_mac_address-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Mac Address',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_gateway_mac_address',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'dc:fe:23:bb:a0:86',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_gateway_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_modelinfo',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_gateway_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_gateway_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom Gateway Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_gateway_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'BRP069C5x',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_indoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_indoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_modelinfo',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_indoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_indoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom IndoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_indoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FXSA25A2VEB',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_indoorunit_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_indoorunit_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'IndoorUnit Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'indoorunit_softwareversion',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_indoorUnit_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_indoorunit_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom IndoorUnit Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_indoorunit_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '19000A03',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_outdoorunit_error_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_outdoorunit_error_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Error Code',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_errorcode',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_None_errorCode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_outdoorunit_error_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom OutdoorUnit Error Code',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_outdoorunit_error_code',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_outdoorunit_model_info-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_outdoorunit_model_info',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'OutdoorUnit Model Info',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'outdoorunit_modelinfo',
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_None_modelInfo',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_outdoorunit_model_info-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom OutdoorUnit Model Info',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_outdoorunit_model_info',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'RXYSA6A7V1B',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dry2[sensor.master_bedroom_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Master Bedroom RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.master_bedroom_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -48562,25 +57788,18 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'target_temp_step': 0.1,
     }),
     'config_entry_id': <ANY>,
     'device_class': None,
@@ -48600,7 +57819,7 @@
     'original_icon': None,
     'original_name': 'Bedroom 1 Room Temperature',
     'platform': 'daikin_onecta',
-    'supported_features': <ClimateEntityFeature: 25>,
+    'supported_features': <ClimateEntityFeature: 16>,
     'translation_key': 'daikin_onecta',
     'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_roomTemperature',
     'unit_of_measurement': None,
@@ -48610,13 +57829,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 22.9,
-      'fan_mode': 'auto',
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'friendly_name': 'Bedroom 1 Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
@@ -48624,22 +57836,20 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_mode': 'none',
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'supported_features': <ClimateEntityFeature: 25>,
-      'target_temp_step': 0.1,
-      'temperature': 22,
+      'supported_features': <ClimateEntityFeature: 16>,
     }),
     'context': <ANY>,
     'entity_id': 'climate.bedroom_1_room_temperature',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'cool',
+    'state': 'dry',
   })
 # ---
 # name: test_dry[climate.bedroom_2_room_temperature-entry]
@@ -48648,25 +57858,18 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'target_temp_step': 0.1,
     }),
     'config_entry_id': <ANY>,
     'device_class': None,
@@ -48686,7 +57889,7 @@
     'original_icon': None,
     'original_name': 'Bedroom 2 Room Temperature',
     'platform': 'daikin_onecta',
-    'supported_features': <ClimateEntityFeature: 25>,
+    'supported_features': <ClimateEntityFeature: 16>,
     'translation_key': 'daikin_onecta',
     'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_roomTemperature',
     'unit_of_measurement': None,
@@ -48695,14 +57898,7 @@
 # name: test_dry[climate.bedroom_2_room_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 23.7,
-      'fan_mode': 'auto',
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
+      'current_temperature': 24.5,
       'friendly_name': 'Bedroom 2 Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
@@ -48710,16 +57906,14 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_mode': 'none',
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'supported_features': <ClimateEntityFeature: 25>,
-      'target_temp_step': 0.1,
-      'temperature': 21,
+      'supported_features': <ClimateEntityFeature: 16>,
     }),
     'context': <ANY>,
     'entity_id': 'climate.bedroom_2_room_temperature',
@@ -48734,12 +57928,6 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -48747,8 +57935,8 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_modes': list([
         'away',
         'none',
@@ -48757,7 +57945,6 @@
         'off',
         'vertical',
       ]),
-      'target_temp_step': 0.1,
     }),
     'config_entry_id': <ANY>,
     'device_class': None,
@@ -48777,7 +57964,7 @@
     'original_icon': None,
     'original_name': 'Bedroom 3 Room Temperature',
     'platform': 'daikin_onecta',
-    'supported_features': <ClimateEntityFeature: 57>,
+    'supported_features': <ClimateEntityFeature: 48>,
     'translation_key': 'daikin_onecta',
     'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_roomTemperature',
     'unit_of_measurement': None,
@@ -48786,14 +57973,7 @@
 # name: test_dry[climate.bedroom_3_room_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 22.8,
-      'fan_mode': '3',
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
+      'current_temperature': 19,
       'friendly_name': 'Bedroom 3 Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
@@ -48802,21 +57982,19 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_mode': 'none',
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'supported_features': <ClimateEntityFeature: 57>,
+      'supported_features': <ClimateEntityFeature: 48>,
       'swing_mode': 'off',
       'swing_modes': list([
         'off',
         'vertical',
       ]),
-      'target_temp_step': 0.1,
-      'temperature': 22,
     }),
     'context': <ANY>,
     'entity_id': 'climate.bedroom_3_room_temperature',
@@ -48831,25 +58009,18 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'target_temp_step': 0.1,
     }),
     'config_entry_id': <ANY>,
     'device_class': None,
@@ -48869,7 +58040,7 @@
     'original_icon': None,
     'original_name': 'Kitchen Room Temperature',
     'platform': 'daikin_onecta',
-    'supported_features': <ClimateEntityFeature: 25>,
+    'supported_features': <ClimateEntityFeature: 16>,
     'translation_key': 'daikin_onecta',
     'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_roomTemperature',
     'unit_of_measurement': None,
@@ -48878,14 +58049,7 @@
 # name: test_dry[climate.kitchen_room_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 23.9,
-      'fan_mode': 'auto',
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
+      'current_temperature': 24.7,
       'friendly_name': 'Kitchen Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
@@ -48893,22 +58057,20 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_mode': 'none',
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'supported_features': <ClimateEntityFeature: 25>,
-      'target_temp_step': 0.1,
-      'temperature': 22,
+      'supported_features': <ClimateEntityFeature: 16>,
     }),
     'context': <ANY>,
     'entity_id': 'climate.kitchen_room_temperature',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
-    'state': 'cool',
+    'state': 'off',
   })
 # ---
 # name: test_dry[climate.lounge_room_temperature-entry]
@@ -49057,25 +58219,18 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'target_temp_step': 0.1,
     }),
     'config_entry_id': <ANY>,
     'device_class': None,
@@ -49095,7 +58250,7 @@
     'original_icon': None,
     'original_name': 'Master Bedroom Room Temperature',
     'platform': 'daikin_onecta',
-    'supported_features': <ClimateEntityFeature: 25>,
+    'supported_features': <ClimateEntityFeature: 16>,
     'translation_key': 'daikin_onecta',
     'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_roomTemperature',
     'unit_of_measurement': None,
@@ -49104,14 +58259,7 @@
 # name: test_dry[climate.master_bedroom_room_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 23.5,
-      'fan_mode': 'auto',
-      'fan_modes': list([
-        'auto',
-        '1',
-        '2',
-        '3',
-      ]),
+      'current_temperature': 25.1,
       'friendly_name': 'Master Bedroom Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
@@ -49119,16 +58267,14 @@
         <HVACMode.COOL: 'cool'>,
         <HVACMode.DRY: 'dry'>,
       ]),
-      'max_temp': 32,
-      'min_temp': 16,
+      'max_temp': None,
+      'min_temp': None,
       'preset_mode': 'none',
       'preset_modes': list([
         'away',
         'none',
       ]),
-      'supported_features': <ClimateEntityFeature: 25>,
-      'target_temp_step': 0.1,
-      'temperature': 22,
+      'supported_features': <ClimateEntityFeature: 16>,
     }),
     'context': <ANY>,
     'entity_id': 'climate.master_bedroom_room_temperature',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -64,6 +64,7 @@ async def test_dry(
 
     assert hass.states.get("climate.lounge_room_temperature").state == HVACMode.DRY
 
+
 async def test_dry2(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
@@ -75,6 +76,7 @@ async def test_dry2(
     await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "dry2")
 
     assert hass.states.get("climate.bedroom_3_room_temperature").state == HVACMode.OFF
+
 
 async def test_altherma(
     hass: HomeAssistant,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -64,6 +64,17 @@ async def test_dry(
 
     assert hass.states.get("climate.lounge_room_temperature").state == HVACMode.DRY
 
+async def test_dry2(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    onecta_auth: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entities."""
+    await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "dry2")
+
+    assert hass.states.get("climate.bedroom_3_room_temperature").state == HVACMode.OFF
 
 async def test_altherma(
     hass: HomeAssistant,


### PR DESCRIPTION
    * custom_components/daikin_onecta/climate.py:
    * tests/snapshots/test_init.ambr:
    * tests/test_init.py: