### PR TITLE
Use async_forward_entry_setups to fix warning, we require now 2024.7.…

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -57,8 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 
-    for component in COMPONENT_TYPES:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(config_entry, component))
+    hass.async_create_task(hass.config_entries.async_forward_entry_setups(config_entry, COMPONENT_TYPES))
 
     return True
 

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 
-    hass.async_create_task(hass.config_entries.async_forward_entry_setups(config_entry, COMPONENT_TYPES))
+    await hass.config_entries.async_forward_entry_setups(config_entry, COMPONENT_TYPES)
 
     return True
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Daikin Onecta",
   "render_readme": true,
-  "homeassistant": "2024.1.2"
+  "homeassistant": "2024.7.0"
 }


### PR DESCRIPTION
…0, fixed #248

    * custom_components/daikin_onecta/__init__.py:
    * hacs.json: