### PR TITLE
Fix device conflict with the official daikin integration

### DIFF
--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -55,7 +55,6 @@ class DaikinOnectaDevice:
                 # Serial numbers are unique identifiers within a specific domain
                 (DOMAIN, self.id)
             },
-            "connections": {(CONNECTION_NETWORK_MAC, mac_add)},
             "manufacturer": "Daikin",
             "model": model,
             "name": self.name,


### PR DESCRIPTION
This will make the devices discovered by the daikin_onecta integration not match the devices discovered by the daikin integration, such that HA will create two independent entities. This way, users who wish to use both integrations can disable the duplicate devices easily.

I had to remove the old devices from `.storage/core.device_registry` and restart home assistant to recreate the devices. 

I don't believe most users will be impacted by this change, the integration works fine with the old device data.
I am open for suggestions on how to handle this entity migration automatically.

Fixes #240
