### PR TITLE
Add support for Daikin homehub, exposes very minimal data to the Daik…

### DIFF
--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -46,9 +46,15 @@ class DaikinOnectaDevice:
         for management_point in management_points:
             management_point_type = management_point["managementPointType"]
             if management_point_type in supported_management_point_types:
-                mac_add = management_point["macAddress"]["value"]
-                model = management_point["modelInfo"]["value"]
-                sw_vers = management_point["firmwareVersion"]["value"]
+                mp = management_point.get("macAddress")
+                if mp is not None:
+                    mac_add = mp["value"]
+                mi = management_point.get("modelInfo")
+                if mi is not None:
+                    model = mi["value"]
+                fw = management_point.get("firmwareVersion")
+                if fw is not None:
+                    sw_vers = fw["value"]
 
         return {
             "identifiers": {

--- a/tests/fixtures/homehub.json
+++ b/tests/fixtures/homehub.json
@@ -1,0 +1,25 @@
+ [
+  {
+    "_id": "6a84eb95-60ea-4c21-8376-a10b3886437f",
+    "id": "6a84eb95-60ea-4c21-8376-a10b3886437f",
+    "type": "homehub",
+    "deviceModel": "homehub",
+    "isCloudConnectionUp": {
+      "settable": false,
+      "value": true
+    },
+    "managementPoints": [
+      {
+        "embeddedId": "gateway",
+        "managementPointType": "gateway",
+        "managementPointCategory": "secondary",
+        "softwareVersion": {
+          "settable": false,
+          "value": "2.3.0"
+        }
+      }
+    ],
+    "embeddedId": "cb4d0c17-4913-4a60-96a7-b7024c88a124",
+    "timestamp": "2024-07-14T05:02:10.478Z"
+  }
+]

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -66009,6 +66009,325 @@
     'state': 'heat_pump',
   })
 # ---
+# name: test_homehub[sensor.homehub_gateway_software_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_gateway_software_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'Gateway Software Version',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': 'gateway_softwareversion',
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_gateway_None_softwareVersion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_gateway_software_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub Gateway Software Version',
+      'icon': 'mdi:information-outline',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_gateway_software_version',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.3.0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_minute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit minute',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_minute',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit minute',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_minute',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_ratelimit_reset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_ratelimit_reset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit ratelimit_reset',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_ratelimit_reset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_ratelimit_reset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit ratelimit_reset',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_ratelimit_reset',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_remaining_day-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_remaining_day',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_day',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_remaining_day',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_remaining_day-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit remaining_day',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_remaining_day',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_remaining_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_remaining_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit remaining_minutes',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_remaining_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_remaining_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit remaining_minutes',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_remaining_minutes',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_retry_after-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.homehub_ratelimit_retry_after',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:information-outline',
+    'original_name': 'RateLimit retry_after',
+    'platform': 'daikin_onecta',
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_retry_after',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_homehub[sensor.homehub_ratelimit_retry_after-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'homehub RateLimit retry_after',
+      'icon': 'mdi:information-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.homehub_ratelimit_retry_after',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_mc80z[binary_sensor.air_purifier_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,6 +55,19 @@ from custom_components.daikin_onecta.diagnostics import async_get_config_entry_d
 from custom_components.daikin_onecta.diagnostics import async_get_device_diagnostics
 
 
+async def test_homehub(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    onecta_auth: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entities."""
+    await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "homehub")
+
+    assert hass.states.get("sensor.homehub_ratelimit_minute").state == '0'
+
+
 async def test_offlinedevice(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,7 +65,7 @@ async def test_homehub(
     """Test entities."""
     await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "homehub")
 
-    assert hass.states.get("sensor.homehub_ratelimit_minute").state == '0'
+    assert hass.states.get("sensor.homehub_ratelimit_minute").state == "0"
 
 
 async def test_offlinedevice(


### PR DESCRIPTION
…in cloud

    * tests/fixtures/homehub.json:
      Added.

    * custom_components/daikin_onecta/device.py:
    * tests/snapshots/test_init.ambr:
    * tests/test_init.py: