### PR TITLE
When the device has a heatupMode in the data don't add an implicit of…

### DIFF
--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -155,7 +155,8 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
                             _LOGGER.info(
                                 "Device '%s:%s' has no heatupMode so add implicit off selection",
                                 self._device.name,
-                                self._embedded_id,)
+                                self._embedded_id,
+                            )
 
                             opt.append(SCHEDULE_OFF)
 

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -148,6 +148,15 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
                                 readableName = scheduleName
                             opt.append(readableName)
 
-        opt.append(SCHEDULE_OFF)
+                        # Only add off when there is no heatupMode, the Altherma hot water tank has this field available, for the
+                        # hot water tank there is no implicit off schedule, you can only select a schedule, not none
+                        heatupMode = management_point.get("heatupMode")
+                        if heatupMode is None:
+                            _LOGGER.info(
+                                "Device '%s:%s' has no heatupMode so add implicit off selection",
+                                self._device.name,
+                                self._embedded_id,)
+
+                            opt.append(SCHEDULE_OFF)
 
         return opt

--- a/tests/fixtures/altherma_schedule.json
+++ b/tests/fixtures/altherma_schedule.json
@@ -1,0 +1,897 @@
+[
+      {
+        "_id": "1ece521b-5401-4a42-acce-6f76fba246aa",
+        "deviceModel": "Altherma",
+        "type": "heating-wlan",
+        "isCloudConnectionUp": {
+          "settable": false,
+          "value": true
+        },
+        "managementPoints": [
+          {
+            "embeddedId": "gateway",
+            "managementPointType": "gateway",
+            "managementPointCategory": "secondary",
+            "firmwareVersion": {
+              "settable": false,
+              "value": "3.5.0",
+              "maxLength": 8
+            },
+            "ipAddress": {
+              "settable": false,
+              "value": "192.168.1.207",
+              "maxLength": 15
+            },
+            "isFirmwareUpdateSupported": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": true
+            },
+            "macAddress": {
+              "settable": false,
+              "value": "00:e9:3a:67:14:a6",
+              "maxLength": 17
+            },
+            "modelInfo": {
+              "settable": false,
+              "value": "BRP069A78",
+              "maxLength": 9
+            },
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "Gateway",
+              "maxLength": 63
+            }
+          },
+          {
+            "embeddedId": "climateControlMainZone",
+            "managementPointType": "climateControl",
+            "managementPointCategory": "primary",
+            "managementPointSubType": "mainZone",
+            "consumptionData": {
+              "settable": false,
+              "requiresReboot": false,
+              "ref": "#consumptionData",
+              "value": {
+                "electrical": {
+                  "heating": {
+                    "d": [
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "w": [
+                      7,
+                      5,
+                      7,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "m": [
+                      609,
+                      297,
+                      187,
+                      159,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      90,
+                      324,
+                      411,
+                      618,
+                      480,
+                      293,
+                      19,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ]
+                  },
+                  "cooling": {
+                    "d": [
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "w": [
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "m": [
+                      0,
+                      0,
+                      0,
+                      0,
+                      20,
+                      28,
+                      51,
+                      74,
+                      16,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ]
+                  }
+                }
+              }
+            },
+            "controlMode": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "roomTemperature",
+              "values": [
+                "leavingWaterTemperature",
+                "externalRoomTemperature",
+                "roomTemperature"
+              ]
+            },
+            "errorCode": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "",
+              "maxLength": 16
+            },
+            "holidayMode": {
+              "settable": true,
+              "requiresReboot": false,
+              "ref": "#holidayMode",
+              "value": {
+                "enabled": false,
+                "startDate": "2023-10-30",
+                "endDate": "2023-11-06"
+              }
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInEmergencyState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInInstallerState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "Altherma",
+              "maxLength": 63
+            },
+            "onOffMode": {
+              "settable": true,
+              "requiresReboot": false,
+              "value": "off",
+              "values": [
+                "off",
+                "on"
+              ]
+            },
+            "operationMode": {
+              "settable": true,
+              "requiresReboot": false,
+              "value": "heating",
+              "values": [
+                "heating",
+                "cooling",
+                "auto"
+              ]
+            },
+            "schedule": {
+              "settable": true,
+              "ref": "#schedule",
+              "value": {
+                "currentMode": {
+                  "settable": false,
+                  "value": "heating",
+                  "values": [
+                    "heating",
+                    "cooling"
+                  ]
+                },
+                "modes": {
+                  "heating": {
+                    "enabled": {
+                      "settable": true,
+                      "requiresReboot": false,
+                      "value": false
+                    },
+                    "currentSchedule": {
+                      "settable": true,
+                      "requiresReboot": false,
+                      "value": "scheduleHeatingRT1",
+                      "values": [
+                        "scheduleHeatingRT1",
+                        "scheduleHeatingRT2",
+                        "scheduleHeatingRT3"
+                      ]
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:10:00",
+                      "maxSchedules": 3,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "roomTemperature": {
+                          "settable": false,
+                          "maxValue": 23,
+                          "minValue": 18,
+                          "stepValue": 1
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "scheduleHeatingRT1": {
+                        "settable": false,
+                        "name": {
+                          "settable": false,
+                          "requiresReboot": false,
+                          "value": "User defined 1"
+                        },
+                        "meta": {
+                          "isReadOnly": false,
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ]
+                        },
+                        "actions": {}
+                      },
+                      "scheduleHeatingRT2": {
+                        "settable": false,
+                        "name": {
+                          "settable": false,
+                          "requiresReboot": false,
+                          "value": "User defined 2"
+                        },
+                        "meta": {
+                          "isReadOnly": false,
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ]
+                        },
+                        "actions": {}
+                      },
+                      "scheduleHeatingRT3": {
+                        "settable": false,
+                        "name": {
+                          "settable": false,
+                          "requiresReboot": false,
+                          "value": "User defined 3"
+                        },
+                        "meta": {
+                          "isReadOnly": false,
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ]
+                        },
+                        "actions": {}
+                      }
+                    }
+                  },
+                  "cooling": {
+                    "enabled": {
+                      "settable": true,
+                      "requiresReboot": false,
+                      "value": false
+                    },
+                    "currentSchedule": {
+                      "settable": true,
+                      "requiresReboot": false,
+                      "value": "scheduleCoolingRT1",
+                      "values": [
+                        "scheduleCoolingRT1"
+                      ]
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:10:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 6,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "roomTemperature": {
+                          "settable": false,
+                          "maxValue": 28,
+                          "minValue": 19,
+                          "stepValue": 1
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "scheduleCoolingRT1": {
+                        "settable": false,
+                        "name": {
+                          "settable": false,
+                          "requiresReboot": false,
+                          "value": "User defined"
+                        },
+                        "meta": {
+                          "isReadOnly": false,
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ]
+                        },
+                        "actions": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "settable": false,
+              "ref": "#sensoryData",
+              "value": {
+                "leavingWaterTemperature": {
+                  "settable": false,
+                  "requiresReboot": false,
+                  "value": 36,
+                  "maxValue": 127,
+                  "minValue": -127,
+                  "stepValue": 1
+                },
+                "outdoorTemperature": {
+                  "settable": false,
+                  "requiresReboot": false,
+                  "value": 12,
+                  "maxValue": 127,
+                  "minValue": -127,
+                  "stepValue": 1
+                },
+                "roomTemperature": {
+                  "settable": false,
+                  "requiresReboot": false,
+                  "value": 19,
+                  "maxValue": 127,
+                  "minValue": -127,
+                  "stepValue": 0.1
+                }
+              }
+            },
+            "setpointMode": {
+              "settable": false,
+              "requiresReboot": true,
+              "value": "weatherDependentHeatingFixedCooling",
+              "values": [
+                "fixed",
+                "weatherDependentHeatingFixedCooling",
+                "weatherDependent"
+              ]
+            },
+            "temperatureControl": {
+              "settable": true,
+              "ref": "#temperatureControl",
+              "value": {
+                "operationModes": {
+                  "auto": {
+                    "setpoints": {
+                      "leavingWaterOffset": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 0,
+                        "maxValue": 10,
+                        "minValue": -10,
+                        "stepValue": 1
+                      },
+                      "roomTemperature": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 20,
+                        "maxValue": 23,
+                        "minValue": 18,
+                        "stepValue": 0.5
+                      }
+                    }
+                  },
+                  "cooling": {
+                    "setpoints": {
+                      "leavingWaterTemperature": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 19,
+                        "maxValue": 20,
+                        "minValue": 18,
+                        "stepValue": 1
+                      },
+                      "roomTemperature": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 20,
+                        "maxValue": 28,
+                        "minValue": 19,
+                        "stepValue": 0.5
+                      }
+                    }
+                  },
+                  "heating": {
+                    "setpoints": {
+                      "leavingWaterOffset": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 0,
+                        "maxValue": 10,
+                        "minValue": -10,
+                        "stepValue": 1
+                      },
+                      "roomTemperature": {
+                        "settable": true,
+                        "requiresReboot": false,
+                        "value": 20,
+                        "maxValue": 23,
+                        "minValue": 18,
+                        "stepValue": 0.5
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "domesticHotWaterTank",
+            "managementPointType": "domesticHotWaterTank",
+            "managementPointCategory": "primary",
+            "consumptionData": {
+              "settable": false,
+              "requiresReboot": false,
+              "ref": "#consumptionData",
+              "value": {
+                "electrical": {
+                  "heating": {
+                    "d": [
+                      0,
+                      0,
+                      0,
+                      2,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      2,
+                      0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "w": [
+                      3,
+                      4,
+                      3,
+                      6,
+                      2,
+                      3,
+                      3,
+                      2,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ],
+                    "m": [
+                      116,
+                      101,
+                      101,
+                      97,
+                      88,
+                      91,
+                      72,
+                      80,
+                      87,
+                      102,
+                      115,
+                      110,
+                      140,
+                      120,
+                      118,
+                      46,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null
+                    ]
+                  }
+                }
+              }
+            },
+            "errorCode": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "",
+              "maxLength": 16
+            },
+            "heatupMode": {
+              "settable": false,
+              "requiresReboot": true,
+              "value": "reheatSchedule",
+              "values": [
+                "reheatOnly",
+                "reheatSchedule",
+                "scheduleOnly"
+              ]
+            },
+            "isHolidayModeActive": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInEmergencyState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInErrorState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInInstallerState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isInWarningState": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "isPowerfulModeActive": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": false
+            },
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "",
+              "maxLength": 63
+            },
+            "onOffMode": {
+              "settable": true,
+              "requiresReboot": false,
+              "value": "on",
+              "values": [
+                "off",
+                "on"
+              ]
+            },
+            "operationMode": {
+              "settable": false,
+              "value": "heating",
+              "values": [
+                "heating"
+              ]
+            },
+            "powerfulMode": {
+              "settable": true,
+              "requiresReboot": false,
+              "value": "off",
+              "values": [
+                "off",
+                "on"
+              ]
+            },
+            "schedule": {
+              "settable": true,
+              "ref": "#schedule",
+              "value": {
+                "currentMode": {
+                  "settable": false,
+                  "value": "heating",
+                  "values": [
+                    "heating"
+                  ]
+                },
+                "modes": {
+                  "heating": {
+                    "enabled": {
+                      "settable": false,
+                      "requiresReboot": false,
+                      "value": true
+                    },
+                    "currentSchedule": {
+                      "settable": true,
+                      "requiresReboot": false,
+                      "value": "scheduleHeatingMode1",
+                      "values": [
+                        "scheduleHeatingMode1"
+                      ]
+                    },
+                    "meta": {
+                      "minIntervalBetweenActions": "00:10:00",
+                      "maxSchedules": 1,
+                      "maxActionsPerActionPeriod": 4,
+                      "consecutiveActionsAllowed": true,
+                      "actionTypes": {
+                        "domesticHotWaterTemperature": {
+                          "settable": false,
+                          "values": [
+                            "eco",
+                            "comfort",
+                            "turn_off"
+                          ]
+                        }
+                      }
+                    },
+                    "schedules": {
+                      "scheduleHeatingMode1": {
+                        "settable": false,
+                        "name": {
+                          "settable": false,
+                          "requiresReboot": false,
+                          "value": "User defined"
+                        },
+                        "meta": {
+                          "isReadOnly": false,
+                          "actionPeriods": [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday"
+                          ]
+                        },
+                        "actions": {
+                          "monday": {
+                            "10:00:00": {
+                              "domesticHotWaterTemperature": "comfort"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sensoryData": {
+              "settable": false,
+              "ref": "#sensoryData",
+              "value": {
+                "tankTemperature": {
+                  "settable": false,
+                  "requiresReboot": false,
+                  "value": 51,
+                  "maxValue": 127,
+                  "minValue": -127,
+                  "stepValue": 1
+                }
+              }
+            },
+            "setpointMode": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "fixed",
+              "values": [
+                "fixed",
+                "weatherDependent"
+              ]
+            },
+            "temperatureControl": {
+              "settable": true,
+              "ref": "#temperatureControl",
+              "value": {
+                "operationModes": {
+                  "heating": {
+                    "setpoints": {
+                      "domesticHotWaterTemperature": {
+                        "settable": false,
+                        "requiresReboot": false,
+                        "value": 45,
+                        "maxValue": 60,
+                        "minValue": 30,
+                        "stepValue": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "embeddedId": "indoorUnitHydro",
+            "managementPointType": "indoorUnitHydro",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "EHVX08S23EJ9W",
+              "maxLength": 16
+            },
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "Indoor Hydro Unit",
+              "maxLength": 63
+            },
+            "softwareVersion": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "0223",
+              "maxLength": 16
+            }
+          },
+          {
+            "embeddedId": "outdoorUnit",
+            "managementPointType": "outdoorUnit",
+            "managementPointCategory": "secondary",
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "Outdoor Unit",
+              "maxLength": 63
+            },
+            "softwareVersion": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "FFFF",
+              "maxLength": 16
+            }
+          },
+          {
+            "embeddedId": "userInterface",
+            "managementPointType": "userInterface",
+            "managementPointCategory": "secondary",
+            "modelInfo": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "EHVX08S23EJ9W",
+              "maxLength": 16
+            },
+            "name": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "User Interface",
+              "maxLength": 63
+            },
+            "softwareVersion": {
+              "settable": false,
+              "requiresReboot": false,
+              "value": "7.7.0",
+              "maxLength": 16
+            }
+          }
+        ],
+        "embeddedId": "6cce8059-4e4e-48bf-bfa4-08ac36d1e7b8",
+        "timestamp": "2025-04-14T08:10:29.621Z",
+        "id": "1ece521b-5401-4a42-acce-6f76fba246aa"
+      }
+]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1259,3 +1259,16 @@ async def test_button(
         await hass.async_block_till_done()
 
         assert len(responses.calls) == 1
+
+
+async def test_altherma_schedule(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    onecta_auth: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entities."""
+    await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "altherma_schedule")
+
+    assert hass.states.get("select.altherma_domestichotwatertank_schedule").state == 'User defined'

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1271,4 +1271,4 @@ async def test_altherma_schedule(
     """Test entities."""
     await snapshot_platform_entities(hass, config_entry, Platform.SENSOR, entity_registry, snapshot, "altherma_schedule")
 
-    assert hass.states.get("select.altherma_domestichotwatertank_schedule").state == 'User defined'
+    assert hass.states.get("select.altherma_domestichotwatertank_schedule").state == "User defined"


### PR DESCRIPTION
…f schedule selection

    * tests/fixtures/altherma_schedule.json: Added.

    * custom_components/daikin_onecta/select.py:
    * tests/test_init.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated scheduling options for Altherma heating systems now ensure that the “off” schedule is only presented when relevant, offering a more precise control experience.
  - Introduced a comprehensive data structure for Altherma heating systems, enhancing insights into device control, status, and consumption metrics.

- **Tests**
  - Added automated tests to verify the behavior of the Altherma scheduling functionality, ensuring reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->