### PR TITLE
Improved check whether schedule can be set to off

### DIFF
--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -148,14 +148,13 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
                                 readableName = scheduleName
                             opt.append(readableName)
 
-                        # Only add off when there is no heatupMode, the Altherma hot water tank has this field available, for the
-                        # hot water tank there is no implicit off schedule, you can only select a schedule, not none
-                        heatupMode = management_point.get("heatupMode")
-                        if heatupMode is None:
+                        # Only add off when the schedule cuurent mode settable is true
+                        if scheduledict["value"]["modes"][currentMode]["enabled"]["settable"]:
                             _LOGGER.info(
-                                "Device '%s:%s' has no heatupMode so add implicit off selection",
+                                "Device '%s:%s' enabled can be set, so providing %s",
                                 self._device.name,
                                 self._embedded_id,
+                                SCHEDULE_OFF
                             )
 
                             opt.append(SCHEDULE_OFF)

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -148,7 +148,7 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
                                 readableName = scheduleName
                             opt.append(readableName)
 
-                        # Only add off when the schedule cuurent mode settable is true
+                        # Only add off when the schedule current mode settable is true
                         if scheduledict["value"]["modes"][currentMode]["enabled"]["settable"]:
                             _LOGGER.info("Device '%s:%s' enabled can be set, so providing %s", self._device.name, self._embedded_id, SCHEDULE_OFF)
 

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -150,12 +150,7 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
 
                         # Only add off when the schedule cuurent mode settable is true
                         if scheduledict["value"]["modes"][currentMode]["enabled"]["settable"]:
-                            _LOGGER.info(
-                                "Device '%s:%s' enabled can be set, so providing %s",
-                                self._device.name,
-                                self._embedded_id,
-                                SCHEDULE_OFF
-                            )
+                            _LOGGER.info("Device '%s:%s' enabled can be set, so providing %s", self._device.name, self._embedded_id, SCHEDULE_OFF)
 
                             opt.append(SCHEDULE_OFF)
 

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -148,7 +148,7 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
                                 readableName = scheduleName
                             opt.append(readableName)
 
-                        # Only add off when the schedule current mode settable is true
+                        # Only add off when the schedule current mode enabled settable is true
                         if scheduledict["value"]["modes"][currentMode]["enabled"]["settable"]:
                             _LOGGER.info("Device '%s:%s' enabled can be set, so providing %s", self._device.name, self._embedded_id, SCHEDULE_OFF)
 


### PR DESCRIPTION
    * custom_components/daikin_onecta/select.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for displaying the "off" schedule option, ensuring it only appears when the current mode's "enabled" state is settable.
  - Updated log messages to accurately reflect the new condition for showing the "off" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->