### PR TITLE
Removed testing with python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.13"]
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v5"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Continuous integration now runs automated tests exclusively on Python 3.13, removing Python 3.12 from the test matrix. This streamlines test runs and ensures a consistent environment across builds. No user-facing functionality is affected by this change. Developers should verify local setups align with Python 3.13 to match CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->