### PR TITLE
Also update the operation list when the device state is changed

### DIFF
--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -284,6 +284,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
         else:
             # Update local cached version
             self._attr_current_operation = operation_mode
+            self._attr_operation_list = self.get_operation_list()
             self.async_write_ha_state()
 
         return result
@@ -300,6 +301,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
                 hwtd = self.hotwatertank_data
                 hwtd["onOffMode"]["value"] = "on"
                 self._attr_current_operation = self.get_current_operation()
+                self._attr_operation_list = self.get_operation_list()
                 self.async_write_ha_state()
         else:
             _LOGGER.debug(
@@ -321,6 +323,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
                 hwtd = self.hotwatertank_data
                 hwtd["onOffMode"]["value"] = "off"
                 self._attr_current_operation = self.get_current_operation()
+                self._attr_operation_list = self.get_operation_list()
                 self.async_write_ha_state()
         else:
             _LOGGER.debug(


### PR DESCRIPTION
    * custom_components/daikin_onecta/water_heater.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operation modes list synchronization with water heater device state following mode or power changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->