### PR TITLE
Translate sensor for rate limit remaing day

### DIFF
--- a/custom_components/daikin_onecta/const.py
+++ b/custom_components/daikin_onecta/const.py
@@ -570,4 +570,13 @@ VALUE_SENSOR_MAPPING = {
         ENTITY_CATEGORY: None,
         TRANSLATION_KEY: "heatingyearlygasconsumption",
     },
+    "RatelimitRemainingDay": {
+        CONF_DEVICE_CLASS: None,
+        CONF_STATE_CLASS: SensorStateClass.MEASUREMENT,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ICON: "mdi:information-outline",
+        ENABLED_DEFAULT: True,
+        ENTITY_CATEGORY: EntityCategory.DIAGNOSTIC,
+        TRANSLATION_KEY: "ratelimitremainingday",
+    },
 }

--- a/custom_components/daikin_onecta/sensor.py
+++ b/custom_components/daikin_onecta/sensor.py
@@ -3,14 +3,12 @@ import logging
 
 from homeassistant.components.sensor import CONF_STATE_CLASS
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_CLASS
 from homeassistant.const import CONF_ICON
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import callback
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -319,11 +317,15 @@ class DaikinLimitSensor(CoordinatorEntity, SensorEntity):
         self._device = device
         self._limit_key = limit_key
         self._attr_has_entity_name = True
-        self._attr_icon = "mdi:information-outline"
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_name = f"RateLimit {self._limit_key}"
         self._attr_unique_id = f"{self._device.id}_limitsensor_{self._limit_key}"
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        sensor_settings = VALUE_SENSOR_MAPPING.get("RatelimitRemainingDay")
+        self._attr_icon = sensor_settings[CONF_ICON]
+        self._attr_device_class = sensor_settings[CONF_DEVICE_CLASS]
+        self._attr_entity_registry_enabled_default = sensor_settings[ENABLED_DEFAULT]
+        self._attr_state_class = sensor_settings[CONF_STATE_CLASS]
+        self._attr_entity_category = sensor_settings[ENTITY_CATEGORY]
+        self._attr_native_unit_of_measurement = sensor_settings[CONF_UNIT_OF_MEASUREMENT]
+        self._attr_translation_key = sensor_settings[TRANSLATION_KEY]
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + "gateway")},
             "name": self._device.name + " " + "gateway",
@@ -334,7 +336,7 @@ class DaikinLimitSensor(CoordinatorEntity, SensorEntity):
         _LOGGER.info(
             "Device '%s' supports sensor '%s'",
             device.name,
-            self._attr_name,
+            self._limit_key,
         )
 
     def update_state(self) -> None:

--- a/custom_components/daikin_onecta/translations/de.json
+++ b/custom_components/daikin_onecta/translations/de.json
@@ -55,6 +55,9 @@
       }
     },
     "sensor": {
+      "ratelimitremainingday": {
+        "name": "Verbleibende für Tag"
+      },
       "coolingdailyelectricalconsumption": {
         "name": "Täglicher Stromverbrauch Kühlung"
       },

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -55,6 +55,9 @@
       }
     },
     "sensor": {
+      "ratelimitremainingday": {
+        "name": "Ratelimit remaining day"
+      },
       "coolingdailyelectricalconsumption": {
         "name": "Cooling daily electrical consumption"
       },

--- a/custom_components/daikin_onecta/translations/nl.json
+++ b/custom_components/daikin_onecta/translations/nl.json
@@ -55,6 +55,9 @@
       }
     },
     "sensor": {
+      "ratelimitremainingday": {
+        "name": "Resterend per dag"
+      },
       "coolingdailyelectricalconsumption": {
         "name": "Dagelijks elektriciteitsverbruik koelen"
       },

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -1656,12 +1656,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'eb618890-5f42-496a-a34f-bae6e49260c2_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -1669,7 +1669,7 @@
 # name: test_altherma3m[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -7423,12 +7423,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -7436,7 +7436,7 @@
 # name: test_altherma[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -8230,12 +8230,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '32db6075-b739-4026-b661-127009254b42_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -8243,7 +8243,7 @@
 # name: test_altherma[sensor.johnny_maaike_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Johnny&Maaike Gateway RateLimit remaining_day',
+      'friendly_name': 'Johnny&Maaike Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -9184,12 +9184,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -9197,7 +9197,7 @@
 # name: test_altherma[sensor.linde_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway RateLimit remaining_day',
+      'friendly_name': 'Linde Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -10138,12 +10138,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -10151,7 +10151,7 @@
 # name: test_altherma[sensor.sanne_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Gateway RateLimit remaining_day',
+      'friendly_name': 'Sanne Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -11092,12 +11092,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -11105,7 +11105,7 @@
 # name: test_altherma[sensor.werkkamer_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Werkkamer Gateway RateLimit remaining_day',
+      'friendly_name': 'Werkkamer Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -17599,12 +17599,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -17612,7 +17612,7 @@
 # name: test_altherma_ratelimit[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -18406,12 +18406,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '32db6075-b739-4026-b661-127009254b42_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -18419,7 +18419,7 @@
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Johnny&Maaike Gateway RateLimit remaining_day',
+      'friendly_name': 'Johnny&Maaike Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -19360,12 +19360,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -19373,7 +19373,7 @@
 # name: test_altherma_ratelimit[sensor.linde_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway RateLimit remaining_day',
+      'friendly_name': 'Linde Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -20314,12 +20314,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -20327,7 +20327,7 @@
 # name: test_altherma_ratelimit[sensor.sanne_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Gateway RateLimit remaining_day',
+      'friendly_name': 'Sanne Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -21268,12 +21268,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -21281,7 +21281,7 @@
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Werkkamer Gateway RateLimit remaining_day',
+      'friendly_name': 'Werkkamer Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -24209,12 +24209,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -24222,7 +24222,7 @@
 # name: test_altherma_schedule[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -28987,12 +28987,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -29000,7 +29000,7 @@
 # name: test_button[sensor.bedroom_1_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 1 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 1 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -29292,12 +29292,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -29305,7 +29305,7 @@
 # name: test_button[sensor.bedroom_2_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 2 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 2 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -29597,12 +29597,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -29610,7 +29610,7 @@
 # name: test_button[sensor.bedroom_3_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 3 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 3 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -29902,12 +29902,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -29915,7 +29915,7 @@
 # name: test_button[sensor.kitchen_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Gateway RateLimit remaining_day',
+      'friendly_name': 'Kitchen Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -30207,12 +30207,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -30220,7 +30220,7 @@
 # name: test_button[sensor.lounge_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Lounge Gateway RateLimit remaining_day',
+      'friendly_name': 'Lounge Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -30512,12 +30512,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -30525,7 +30525,7 @@
 # name: test_button[sensor.master_bathroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bathroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bathroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -30817,12 +30817,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -30830,7 +30830,7 @@
 # name: test_button[sensor.master_bedroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bedroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bedroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -34250,7 +34250,7 @@
 # name: test_climate[button.altherma_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Altherma Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -34299,7 +34299,7 @@
 # name: test_climate[button.johnny_maaike_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Johnny&Maaike Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -34348,7 +34348,7 @@
 # name: test_climate[button.linde_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Linde Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -34446,7 +34446,7 @@
 # name: test_climate[button.werkkamer_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Werkkamer Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -36563,12 +36563,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -36576,7 +36576,7 @@
 # name: test_climate[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -37370,12 +37370,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '32db6075-b739-4026-b661-127009254b42_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -37383,7 +37383,7 @@
 # name: test_climate[sensor.johnny_maaike_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Johnny&Maaike Gateway RateLimit remaining_day',
+      'friendly_name': 'Johnny&Maaike Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -38324,12 +38324,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -38337,7 +38337,7 @@
 # name: test_climate[sensor.linde_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Gateway RateLimit remaining_day',
+      'friendly_name': 'Linde Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -39278,12 +39278,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -39291,7 +39291,7 @@
 # name: test_climate[sensor.sanne_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Gateway RateLimit remaining_day',
+      'friendly_name': 'Sanne Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -40232,12 +40232,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -40245,7 +40245,7 @@
 # name: test_climate[sensor.werkkamer_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Werkkamer Gateway RateLimit remaining_day',
+      'friendly_name': 'Werkkamer Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -42425,12 +42425,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -42438,7 +42438,7 @@
 # name: test_climate_fixedfanmode[sensor.werkkamer_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Werkkamer Gateway RateLimit remaining_day',
+      'friendly_name': 'Werkkamer Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -44883,12 +44883,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '71f33ee1-a82d-4f08-8f61-bf25fd872731_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -44896,7 +44896,7 @@
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Laurens Gateway RateLimit remaining_day',
+      'friendly_name': 'Laurens Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -45891,12 +45891,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '27920256-e0af-4780-8f5f-1f88d8fdf0ba_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -45904,7 +45904,7 @@
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Woonkamer airco Gateway RateLimit remaining_day',
+      'friendly_name': 'Woonkamer airco Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -51143,12 +51143,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -51156,7 +51156,7 @@
 # name: test_dry2[sensor.bedroom_1_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 1 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 1 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -51448,12 +51448,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -51461,7 +51461,7 @@
 # name: test_dry2[sensor.bedroom_2_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 2 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 2 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -51753,12 +51753,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -51766,7 +51766,7 @@
 # name: test_dry2[sensor.bedroom_3_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 3 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 3 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -52058,12 +52058,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -52071,7 +52071,7 @@
 # name: test_dry2[sensor.kitchen_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Gateway RateLimit remaining_day',
+      'friendly_name': 'Kitchen Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -52363,12 +52363,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -52376,7 +52376,7 @@
 # name: test_dry2[sensor.lounge_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Lounge Gateway RateLimit remaining_day',
+      'friendly_name': 'Lounge Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -52668,12 +52668,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -52681,7 +52681,7 @@
 # name: test_dry2[sensor.master_bathroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bathroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bathroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -52973,12 +52973,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -52986,7 +52986,7 @@
 # name: test_dry2[sensor.master_bedroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bedroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bedroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -57730,12 +57730,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -57743,7 +57743,7 @@
 # name: test_dry[sensor.bedroom_1_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 1 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 1 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -58035,12 +58035,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -58048,7 +58048,7 @@
 # name: test_dry[sensor.bedroom_2_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 2 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 2 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -58340,12 +58340,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -58353,7 +58353,7 @@
 # name: test_dry[sensor.bedroom_3_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Bedroom 3 Gateway RateLimit remaining_day',
+      'friendly_name': 'Bedroom 3 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -58645,12 +58645,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -58658,7 +58658,7 @@
 # name: test_dry[sensor.kitchen_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Gateway RateLimit remaining_day',
+      'friendly_name': 'Kitchen Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -58950,12 +58950,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -58963,7 +58963,7 @@
 # name: test_dry[sensor.lounge_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Lounge Gateway RateLimit remaining_day',
+      'friendly_name': 'Lounge Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -59255,12 +59255,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -59268,7 +59268,7 @@
 # name: test_dry[sensor.master_bathroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bathroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bathroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -59560,12 +59560,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -59573,7 +59573,7 @@
 # name: test_dry[sensor.master_bedroom_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Bedroom Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Bedroom Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -60645,12 +60645,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '13995b32-fc6e-43ed-918e-5d2b01095ccb_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -60658,7 +60658,7 @@
 # name: test_fanmode[sensor.sala_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sala Gateway RateLimit remaining_day',
+      'friendly_name': 'Sala Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -62247,12 +62247,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '7edb544e-2c53-405b-98bc-3d9392f4d1f9_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -62260,7 +62260,7 @@
 # name: test_gas[sensor.my_living_room_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'My Living Room Gateway RateLimit remaining_day',
+      'friendly_name': 'My Living Room Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -63344,12 +63344,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '13995b32-fc6e-43ed-918e-5d2b01095ccb_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -63357,7 +63357,7 @@
 # name: test_holidaymode[sensor.ndj_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ Gateway RateLimit remaining_day',
+      'friendly_name': 'NDJ Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -63513,12 +63513,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '6a84eb95-60ea-4c21-8376-a10b3886437f_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -63526,7 +63526,7 @@
 # name: test_homehub[sensor.homehub_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'homehub gateway RateLimit remaining_day',
+      'friendly_name': 'homehub gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -65271,12 +65271,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -65284,7 +65284,7 @@
 # name: test_mc80z[sensor.air_purifier_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'air-purifier Gateway RateLimit remaining_day',
+      'friendly_name': 'air-purifier Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -66399,12 +66399,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '4e19a975-b0e4-4ae1-8439-c037e7d0df01_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -66412,7 +66412,7 @@
 # name: test_mc80z[sensor.vloerverwarming_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Vloerverwarming Gateway RateLimit remaining_day',
+      'friendly_name': 'Vloerverwarming Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -68088,12 +68088,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': 'b84e8af3-310a-4e6e-8e52-295573423485_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -68101,7 +68101,7 @@
 # name: test_minimal_data[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -69620,12 +69620,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -69633,7 +69633,7 @@
 # name: test_offlinedevice[sensor.studio_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Studio Gateway RateLimit remaining_day',
+      'friendly_name': 'Studio Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -70280,12 +70280,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '7edb544e-2c53-405b-98bc-3d9392f4d1f9_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -70293,7 +70293,7 @@
 # name: test_schedule[sensor.master_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Master Gateway RateLimit remaining_day',
+      'friendly_name': 'Master Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -70970,12 +70970,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '95c2f177-dd7a-4bdc-ad48-1a7f47f34a01_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -70983,7 +70983,7 @@
 # name: test_ururu[sensor.daikinap95800_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'DaikinAP95800 Gateway RateLimit remaining_day',
+      'friendly_name': 'DaikinAP95800 Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
@@ -73045,12 +73045,12 @@
     }),
     'original_device_class': None,
     'original_icon': 'mdi:information-outline',
-    'original_name': 'RateLimit remaining_day',
+    'original_name': 'Ratelimit remaining day',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'ratelimitremainingday',
     'unique_id': '1ece521b-5401-4a42-acce-6f76fba246aa_limitsensor_remaining_day',
     'unit_of_measurement': None,
   })
@@ -73058,7 +73058,7 @@
 # name: test_water_heater[sensor.altherma_gateway_ratelimit_remaining_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Gateway RateLimit remaining_day',
+      'friendly_name': 'Altherma Gateway Ratelimit remaining day',
       'icon': 'mdi:information-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),


### PR DESCRIPTION
    * custom_components/daikin_onecta/const.py:
    * custom_components/daikin_onecta/sensor.py:
    * custom_components/daikin_onecta/translations/de.json:
    * custom_components/daikin_onecta/translations/en.json:
    * custom_components/daikin_onecta/translations/nl.json:
    * tests/snapshots/test_init.ambr:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced rate limit remaining day sensor that displays information as a diagnostic entity enabled by default, providing state measurement tracking.

* **Documentation**
  * Added complete multilingual translation support for the new sensor across German, English, and Dutch with localized display labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->