### PR TITLE
Added support for Norwegian Bokmål (nb) and Norwegian Nynorsk (nn)

### DIFF
--- a/custom_components/daikin_onecta/translations/nb.json
+++ b/custom_components/daikin_onecta/translations/nb.json
@@ -1,0 +1,283 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "high_scan_interval": "Oppdateringsintervall for høy frekvens (minutter)",
+          "low_scan_interval": "Oppdateringsintervall for lav frekvens (minutter)",
+          "high_scan_start": "Starttidspunkt for høy frekvensperiode",
+          "low_scan_start": "Starttidspunkt for lav frekvensperiode",
+          "scan_ignore": "Antall sekunder som dataopdatering ignoreres etter en kommando"
+        },
+        "description": "Konfigurer Daikin Onecta Cloud polling",
+        "title": "Daikin Onecta"
+      }
+    }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Integrasjonen er allerede konfigurert.",
+      "cannot_connect": "Kunne ikke koble til Daikin Cloud.",
+      "init_failed": "Kunne ikke initialisere Daikin API.",
+      "token_retrieval_failed": "Kunne ikke hente tilgangstokensett."
+    },
+    "error": {
+      "cannot_connect": "Kunne ikke koble til (tilkobling)",
+      "device_fail": "Uventet feil",
+      "device_timeout": "Kunne ikke koble til (timeout)",
+      "forbidden": "Ugyldig autentisering",
+      "invalid_auth": "Ugyldig autentisering",
+      "unknown": "Uventet feil"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "email": "E-postadresse",
+          "password": "Passord"
+        },
+        "description": "Skriv inn IP adresse av Daikin AC.\n\n Merk at API-n\u00f8kkel og Passord bare brukes av henholdsvis BRP072Cxx og SKYFi-enheter.",
+        "title": "Konfigurer Daikin Onecta"
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "schedule": {
+        "name": "Tidsplan"
+      }
+    },
+    "switch": {
+      "streamermode": {
+        "name": "Streamer-modus"
+      },
+      "economode": {
+        "name": "Økonomimodus"
+      }
+    },
+    "sensor": {
+      "ratelimitremainingday": {
+        "name": "Gjenstår i dag"
+      },
+      "coolingdailyelectricalconsumption": {
+        "name": "Daglig strømforbruk kjøling"
+      },
+      "coolingweeklyelectricalconsumption": {
+        "name": "Ukentlig strømforbruk kjøling"
+      },
+      "coolingyearlyelectricalconsumption": {
+        "name": "Årlig strømforbruk kjøling"
+      },
+      "heatingdailyelectricalconsumption": {
+        "name": "Daglig strømforbruk oppvarming"
+      },
+      "heatingweeklyelectricalconsumption": {
+        "name": "Ukentlig strømforbruk oppvarming"
+      },
+      "heatingyearlyelectricalconsumption": {
+        "name": "Årlig strømforbruk oppvarming"
+      },
+      "coolingdailygasconsumption": {
+        "name": "Daglig gassforbruk kjøling"
+      },
+      "coolingweeklygasconsumption": {
+        "name": "Ukentlig gassforbruk kjøling"
+      },
+      "coolingyearlygasconsumption": {
+        "name": "Årlig gassforbruk kjøling"
+      },
+      "heatingdailygasconsumption": {
+        "name": "Daglig gassforbruk oppvarming"
+      },
+      "heatingweeklygasconsumption": {
+        "name": "Ukentlig gassforbruk oppvarming"
+      },
+      "heatingyearlygasconsumption": {
+        "name": "Årlig gassforbruk oppvarming"
+      },
+      "ipaddress": {
+        "name": "IP-adresse"
+      },
+      "tanktemperature": {
+        "name": "Tanktemperatur"
+      },
+      "heatupmode": {
+        "name": "Oppvarmingsmodus"
+      },
+      "outdoortemperature": {
+        "name": "Utetemperatur"
+      },
+      "leavingwatertemperature": {
+        "name": "Utgående vanntemperatur"
+      },
+      "errorcode": {
+        "name": "Feilkode"
+      },
+      "setpointmode": {
+        "name": "Setpunkt-modus"
+      },
+      "powerfulmode": {
+        "name": "Kraftig modus"
+      },
+      "roomtemperature": {
+        "name": "Romtemperatur"
+      },
+      "onoffmode": {
+        "name": "Av/På-modus"
+      },
+      "controlmode": {
+        "name": "Kontrollmodus"
+      },
+      "roomhumidity": {
+        "name": "Romfuktighet"
+      },
+      "pm1concentration": {
+        "name": "PM1-konsentrasjon"
+      },
+      "pm25concentration": {
+        "name": "PM2,5-konsentrasjon"
+      },
+      "operationmode": {
+        "name": "Driftsmodus"
+      },
+      "airpurificationmode": {
+        "name": "Luftrensingmodus"
+      },
+      "wificonnectionssid": {
+        "name": "WiFi-tilkoblings-SSID"
+      },
+      "wificonnectionstrength": {
+        "name": "WiFi-tilkoblingsstyrke"
+      },
+      "ssid": {
+        "name": "SSID"
+      },
+      "pm10concentration": {
+        "name": "PM10-konsentrasjon"
+      },
+      "leavingwateroffset": {
+        "name": "Offset for utgående vann"
+      },
+      "calculatedleavingwatertemperature": {
+        "name": "Beregnet utgående vanntemperatur"
+      },
+      "heatexchangertemperature": {
+        "name": "Varmevekslertemperatur"
+      },
+      "suctiontemperature": {
+        "name": "Sugetemperatur"
+      },
+      "deltad": {
+        "name": "DeltaD"
+      },
+      "drykeepsetting": {
+        "name": "Innstilling for tørr oppbevaring"
+      },
+      "fanmotorrotationspeed": {
+        "name": "Rotasjonshastighet for ventilatormotor"
+      },
+      "datetime": {
+        "name": "Dato/tid"
+      },
+      "regioncode": {
+        "name": "Regionkode"
+      },
+      "timezone": {
+        "name": "Tidssone"
+      }
+    },
+    "binary_sensor": {
+      "isholidaymodeactive": {
+        "name": "Er feriemodus aktiv"
+      },
+      "isinerrorstate": {
+        "name": "Er i feiltilstand"
+      },
+      "isinwarningstate": {
+        "name": "Er i advarselstilstand"
+      },
+      "isininstallerstate": {
+        "name": "Er i installasjonstilstand"
+      },
+      "isinemergencystate": {
+        "name": "Er i nødtilstand"
+      },
+      "ispowerfulmodeactive": {
+        "name": "Er kraftig modus aktiv"
+      },
+      "iscoolheatmaster": {
+        "name": "Er kjøl-/varmemaster"
+      },
+      "isinmodeconflict": {
+        "name": "Er i moduskonflikt"
+      },
+      "isincautionstate": {
+        "name": "Er i forsiktighetstilstand"
+      },
+      "islockfunctionenabled": {
+        "name": "Er låsfunksjon aktivert"
+      },
+      "ledenabled": {
+        "name": "LED aktivert"
+      },
+      "isfirmwareupdatesupported": {
+        "name": "Støttes firmware-oppdatering"
+      },
+      "daylightsavingtimeenabled": {
+        "name": "Sommertid aktivert"
+      }
+    },
+    "climate": {
+      "roomtemperature": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "quiet": "Stille",
+              "1": "1",
+              "2": "2",
+              "3": "3",
+              "4": "4",
+              "5": "5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "stop": "Stopp",
+              "swing": "Sving",
+              "floorheatingairflow": "Gulvvarme-luftstrøm",
+              "windnice": "Komfortabel luftstrøm"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "stop": "Stopp",
+              "swing": "Sving"
+            }
+          }
+        }
+      }
+    }
+  },
+  "issues": {
+    "day_rate_limit": {
+      "title": "Daglig begrenset frekvens nådd",
+      "description": "Du har nådd din daglige grense for anrop til Daikin Cloud. Kontroller pollefrekvensen i Daikin Onecta-konfigurasjonen."
+    },
+    "minute_rate_limit": {
+      "title": "Minutt-basert begrenset frekvens nådd",
+      "description": "Du har nådd din minutt-baserte grense for anrop til Daikin Cloud. Ikke gjør så mange anrop til Daikin-enhetene på ett minutt."
+    }
+  },
+  "system_health": {
+    "info": {
+      "api_status": "API-server",
+      "oauth2_status": "OAuth2-server",
+      "max_minute": "Maksimum per minutt",
+      "max_day": "Maksimum per dag",
+      "remaining_minute": "Gjenstår per minutt",
+      "remaining_day": "Gjenstår per dag",
+      "retry_after": "Prøv på nytt etter",
+      "ratelimit_reset": "Tilbakestilling av frekvensgrense",
+      "oauth2_token_valid": "OAuth2-token gyldig"
+    }
+  }
+}

--- a/custom_components/daikin_onecta/translations/nn.json
+++ b/custom_components/daikin_onecta/translations/nn.json
@@ -1,0 +1,283 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "high_scan_interval": "Oppdateringsintervall for høgfrekvens (minutt)",
+          "low_scan_interval": "Oppdateringsintervall for lågfrekvens (minutt)",
+          "high_scan_start": "Starttidspunkt for høgfrekvensperiode",
+          "low_scan_start": "Starttidspunkt for lågfrekvensperiode",
+          "scan_ignore": "Tal sekund som dataoppdateringar vert ignorert etter ein kommando"
+        },
+        "description": "Konfigurer polling mot Daikin Onecta Cloud",
+        "title": "Daikin Onecta"
+      }
+    }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Integrasjonen er allereie konfigurert.",
+      "cannot_connect": "Kunne ikkje koble til Daikin Cloud.",
+      "init_failed": "Kunne ikkje initialisere Daikin API.",
+      "token_retrieval_failed": "Kunne ikkje hente tilgangstoken."
+    },
+    "error": {
+      "cannot_connect": "Kunne ikkje koble til (tilkobling)",
+      "device_fail": "Uventa feil",
+      "device_timeout": "Kunne ikkje koble til (timeout)",
+      "forbidden": "Ugyldig autentisering",
+      "invalid_auth": "Ugyldig autentisering",
+      "unknown": "Uventa feil"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "email": "E-postadresse",
+          "password": "Passord"
+        },
+        "description": "Skriv inn IP-adressa til Daikin AC.\n\nMerk at API-nøkkel og passord berre vert brukt av henholdsvis BRP072Cxx og SKYFi-einingar.",
+        "title": "Konfigurer Daikin Onecta"
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "schedule": {
+        "name": "Tidsplan"
+      }
+    },
+    "switch": {
+      "streamermode": {
+        "name": "Streamer-modus"
+      },
+      "economode": {
+        "name": "Økonomimodus"
+      }
+    },
+    "sensor": {
+      "ratelimitremainingday": {
+        "name": "Att i dag"
+      },
+      "coolingdailyelectricalconsumption": {
+        "name": "Dagleg straumforbruk kjøling"
+      },
+      "coolingweeklyelectricalconsumption": {
+        "name": "Vekeleg straumforbruk kjøling"
+      },
+      "coolingyearlyelectricalconsumption": {
+        "name": "Årleg straumforbruk kjøling"
+      },
+      "heatingdailyelectricalconsumption": {
+        "name": "Dagleg straumforbruk oppvarming"
+      },
+      "heatingweeklyelectricalconsumption": {
+        "name": "Vekeleg straumforbruk oppvarming"
+      },
+      "heatingyearlyelectricalconsumption": {
+        "name": "Årleg straumforbruk oppvarming"
+      },
+      "coolingdailygasconsumption": {
+        "name": "Dagleg gassforbruk kjøling"
+      },
+      "coolingweeklygasconsumption": {
+        "name": "Vekeleg gassforbruk kjøling"
+      },
+      "coolingyearlygasconsumption": {
+        "name": "Årleg gassforbruk kjøling"
+      },
+      "heatingdailygasconsumption": {
+        "name": "Dagleg gassforbruk oppvarming"
+      },
+      "heatingweeklygasconsumption": {
+        "name": "Vekeleg gassforbruk oppvarming"
+      },
+      "heatingyearlygasconsumption": {
+        "name": "Årleg gassforbruk oppvarming"
+      },
+      "ipaddress": {
+        "name": "IP-adresse"
+      },
+      "tanktemperature": {
+        "name": "Tanktemperatur"
+      },
+      "heatupmode": {
+        "name": "Oppvarmingsmodus"
+      },
+      "outdoortemperature": {
+        "name": "Utetemperatur"
+      },
+      "leavingwatertemperature": {
+        "name": "Utgåande vanntemperatur"
+      },
+      "errorcode": {
+        "name": "Feilkode"
+      },
+      "setpointmode": {
+        "name": "Setpunktmodus"
+      },
+      "powerfulmode": {
+        "name": "Kraftig modus"
+      },
+      "roomtemperature": {
+        "name": "Romtemperatur"
+      },
+      "onoffmode": {
+        "name": "Av/På-modus"
+      },
+      "controlmode": {
+        "name": "Kontrollmodus"
+      },
+      "roomhumidity": {
+        "name": "Romfuktigheit"
+      },
+      "pm1concentration": {
+        "name": "PM1-konsentrasjon"
+      },
+      "pm25concentration": {
+        "name": "PM2,5-konsentrasjon"
+      },
+      "operationmode": {
+        "name": "Driftsmodus"
+      },
+      "airpurificationmode": {
+        "name": "Luftrensemodus"
+      },
+      "wificonnectionssid": {
+        "name": "WiFi-tilkoblings-SSID"
+      },
+      "wificonnectionstrength": {
+        "name": "WiFi-tilkoblingsstyrke"
+      },
+      "ssid": {
+        "name": "SSID"
+      },
+      "pm10concentration": {
+        "name": "PM10-konsentrasjon"
+      },
+      "leavingwateroffset": {
+        "name": "Avvik for utgåande vatn"
+      },
+      "calculatedleavingwatertemperature": {
+        "name": "Berekna utgåande vanntemperatur"
+      },
+      "heatexchangertemperature": {
+        "name": "Varmevekslartemperatur"
+      },
+      "suctiontemperature": {
+        "name": "Sugetemperatur"
+      },
+      "deltad": {
+        "name": "DeltaD"
+      },
+      "drykeepsetting": {
+        "name": "Innstilling for tørking/oppbevaring"
+      },
+      "fanmotorrotationspeed": {
+        "name": "Rotasjonshastigheit for viftemotor"
+      },
+      "datetime": {
+        "name": "Dato/tid"
+      },
+      "regioncode": {
+        "name": "Regionkode"
+      },
+      "timezone": {
+        "name": "Tidssone"
+      }
+    },
+    "binary_sensor": {
+      "isholidaymodeactive": {
+        "name": "Feriemodus aktiv"
+      },
+      "isinerrorstate": {
+        "name": "Er i feiltilstand"
+      },
+      "isinwarningstate": {
+        "name": "Er i varseltilstand"
+      },
+      "isininstallerstate": {
+        "name": "Er i installasjonsmodus"
+      },
+      "isinemergencystate": {
+        "name": "Er i nødtilstand"
+      },
+      "ispowerfulmodeactive": {
+        "name": "Kraftig modus aktiv"
+      },
+      "iscoolheatmaster": {
+        "name": "Er kjøle-/varmemaster"
+      },
+      "isinmodeconflict": {
+        "name": "Er i moduskonflikt"
+      },
+      "isincautionstate": {
+        "name": "Er i føre-var-tilstand"
+      },
+      "islockfunctionenabled": {
+        "name": "Låsfunksjon aktivert"
+      },
+      "ledenabled": {
+        "name": "LED aktivert"
+      },
+      "isfirmwareupdatesupported": {
+        "name": "Støttar firmware-oppdatering"
+      },
+      "daylightsavingtimeenabled": {
+        "name": "Sommartid aktivert"
+      }
+    },
+    "climate": {
+      "roomtemperature": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "quiet": "Stille",
+              "1": "1",
+              "2": "2",
+              "3": "3",
+              "4": "4",
+              "5": "5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "stop": "Stopp",
+              "swing": "Sving",
+              "floorheatingairflow": "Golvvarme-luftstraum",
+              "windnice": "Komfortabel luftstraum"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "stop": "Stopp",
+              "swing": "Sving"
+            }
+          }
+        }
+      }
+    }
+  },
+  "issues": {
+    "day_rate_limit": {
+      "title": "Dagleg grense for spørringar nådd",
+      "description": "Du har nådd den daglege grensa for kall til Daikin Cloud. Sjekk polingsfrekvensen i Daikin Onecta-konfigurasjonen."
+    },
+    "minute_rate_limit": {
+      "title": "Minuttvis grense for spørringar nådd",
+      "description": "Du har nådd den minuttvise grensa for kall til Daikin Cloud. Ikkje utfør så mange kall mot Daikin-einingane på eitt minutt."
+    }
+  },
+  "system_health": {
+    "info": {
+      "api_status": "API-tenar",
+      "oauth2_status": "OAuth2-tenar",
+      "max_minute": "Maksimum per minutt",
+      "max_day": "Maksimum per dag",
+      "remaining_minute": "Att per minutt",
+      "remaining_day": "Att per dag",
+      "retry_after": "Prøv på nytt etter",
+      "ratelimit_reset": "Tilbakestilling av frekvensgrense",
+      "oauth2_token_valid": "OAuth2-token gyldig"
+    }
+  }
+}


### PR DESCRIPTION
Norwegian consists of two written languages Bokmål (nb) and Nynorsk (nn). I have added translation for them both.

I did not get the Norwegian translation from @olekenneth to work since I don't think there is a "no" translation file. 
@olekenneth: Can you confirm if your translation works? If it doesn't I guess we can remove the "no.json" file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Norwegian language support for the Daikin Onecta Home Assistant integration, providing both Bokmål and Nynorsk translation variants. Includes complete localization for all configuration workflows, user interface text, error and abort messages, and full entity naming with descriptions for sensors, binary sensors, switches, select controls, climate entities, and system health status labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->