### PR TITLE
New names added to fi translation and a fixed value

### DIFF
--- a/custom_components/daikin_onecta/translations/fi.json
+++ b/custom_components/daikin_onecta/translations/fi.json
@@ -285,10 +285,10 @@
       "oauth2_status": "OAuth2-palvelin",
       "max_minute": "Enimmäismäärä minuutissa",
       "max_day": "Enimmäismäärä päivässä",
-      "remaining_minute": "Jäljellä oleva minuutti",
-      "remaining_day": "Jäljellä oleva päivä",
+      "remaining_minute": "Jäljellä minuutissa",
+      "remaining_day": "Jäljellä päivässä",
       "retry_after": "Yritä uudelleen jälkeen",
-      "ratelimit_reset": "Kysely rajan palautus",
+      "ratelimit_reset": "Kyselyrajan nollaus",
       "oauth2_token_valid": "OAuth2-tunnus voimassa"
     }
   }


### PR DESCRIPTION
New names added (wrong_account and monthly consumptions)
Swing translation changed
Indentation aligned from 4 spaces to 2 spaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swing mode climate control support for Daikin Onecta devices
* **Localization**
  * Significantly expanded Finnish translations: setup prompts, error messages, device/entity names (sensors, binary sensors, switches, selects), climate state mappings (fan/swing), issue notices for rate limits, and system health info texts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->