### PR TITLE
Set Daikin as manufacturer for all device info

### DIFF
--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -38,6 +38,8 @@ class DaikinOnectaDevice:
         return result
 
     def fill_device_info(self, device_info, management_point_type):
+        manufacturer = {"manufacturer": "Daikin"}
+        device_info.update(**manufacturer)
         management_points = self.daikin_data.get("managementPoints", [])
         for management_point in management_points:
             if management_point_type == management_point["managementPointType"]:
@@ -81,7 +83,6 @@ class DaikinOnectaDevice:
                 (DOMAIN, self.id)
             },
             connections={(CONNECTION_NETWORK_MAC, mac_add)},
-            manufacturer="Daikin",
             name=self.name,
             model_id=devicemodel,
         )


### PR DESCRIPTION
    * custom_components/daikin_onecta/device.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of device manufacturer information configuration.

---

**Note:** This release includes internal technical improvements with no visible changes to end-user functionality or device behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->