### PR TITLE
Add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14"]
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended test coverage to include Python 3.14 in the CI pipeline alongside Python 3.13, ensuring broader compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->