### PR TITLE
Updated naming for pytest with 3.14

### DIFF
--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -123,7 +123,11 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         self._setpoint = setpoint
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_unique_id = f"{self._device.id}_{self._setpoint}"
-        self._attr_device_info = {"identifiers": {(DOMAIN, self._device.id)}}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, self._device.id)},
+            "name": self._device.name
+        }
+        self._attr_has_entity_name = True
         self._device.fill_device_info(self._attr_device_info, "gateway")
         sensor_settings = VALUE_SENSOR_MAPPING.get(setpoint)
         self._attr_translation_key = sensor_settings[TRANSLATION_KEY]
@@ -251,10 +255,9 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def name(self):
-        device_name = self._device.name
         myname = self._setpoint[0].upper() + self._setpoint[1:]
         readable = re.findall("[A-Z][^A-Z]*", myname)
-        return f"{device_name} {' '.join(readable)}"
+        return f"{' '.join(readable)}"
 
     def get_current_temperature(self):
         current_temp = None

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -123,10 +123,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         self._setpoint = setpoint
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_unique_id = f"{self._device.id}_{self._setpoint}"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, self._device.id)},
-            "name": self._device.name
-        }
+        self._attr_device_info = {"identifiers": {(DOMAIN, self._device.id)}, "name": self._device.name}
         self._attr_has_entity_name = True
         self._device.fill_device_info(self._attr_device_info, "gateway")
         sensor_settings = VALUE_SENSOR_MAPPING.get(setpoint)

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -65,7 +65,6 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
             "via_device": (DOMAIN, self._device.id),
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
-        #        self._attr_has_entity_name = True
         self.update_state()
         if self.supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:
             _LOGGER.debug("Device '%s' tank temperature is settable", device.name)

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -64,6 +64,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
             "name": self._device.name,
             "via_device": (DOMAIN, self._device.id),
         }
+        self._attr_has_entity_name = True
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self.update_state()
         if self.supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -70,7 +70,6 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
             _LOGGER.debug("Device '%s' tank temperature is settable", device.name)
 
     def update_state(self) -> None:
-        self._attr_name = self._device.name
         self._attr_supported_features = self.get_supported_features()
         self._attr_current_temperature = self.get_current_temperature()
         self._attr_target_temperature = self.get_target_temperature()

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -65,7 +65,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
             "via_device": (DOMAIN, self._device.id),
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
-#        self._attr_has_entity_name = True
+        #        self._attr_has_entity_name = True
         self.update_state()
         if self.supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:
             _LOGGER.debug("Device '%s' tank temperature is settable", device.name)

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -62,10 +62,11 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
         mpt = management_point_type[0].upper() + management_point_type[1:]
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
-            "name": self._device.name + " " + mpt,
+            "name": self._device.name,
             "via_device": (DOMAIN, self._device.id),
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
+        self._attr_has_entity_name = True
         self.update_state()
         if self.supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:
             _LOGGER.debug("Device '%s' tank temperature is settable", device.name)

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -59,7 +59,6 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_unique_id = f"{self._device.id}"
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name,

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -65,7 +65,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
             "via_device": (DOMAIN, self._device.id),
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
-        self._attr_has_entity_name = True
+#        self._attr_has_entity_name = True
         self.update_state()
         if self.supported_features & WaterHeaterEntityFeature.TARGET_TEMPERATURE:
             _LOGGER.debug("Device '%s' tank temperature is settable", device.name)

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -1886,7 +1886,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -13089,7 +13089,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -24292,7 +24292,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -26750,7 +26750,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -33936,7 +33936,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -33988,7 +33988,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34040,7 +34040,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34091,7 +34091,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34143,7 +34143,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34194,7 +34194,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -39258,7 +39258,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -39315,7 +39315,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39374,7 +39374,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39433,7 +39433,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39492,7 +39492,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39545,7 +39545,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -39602,7 +39602,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -44792,7 +44792,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -44818,7 +44818,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -67572,7 +67572,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.my_living_room',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -67814,7 +67814,7 @@
 # name: test_holidaymode[binary_sensor.ndj_domestichotwaterflowthrough_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is holiday mode active',
+      'friendly_name': 'NDJ Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -67866,7 +67866,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is in error state',
+      'friendly_name': 'NDJ Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -67918,7 +67918,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is in warning state',
+      'friendly_name': 'NDJ Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -68471,7 +68471,7 @@
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Error code',
+      'friendly_name': 'NDJ Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -68522,7 +68522,7 @@
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_on_off_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough On/Off mode',
+      'friendly_name': 'NDJ On/Off mode',
       'icon': 'mdi:toggle-switch-variant',
     }),
     'context': <ANY>,
@@ -68711,7 +68711,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.ndj',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -68737,7 +68737,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough',
+      'friendly_name': 'NDJ',
       'max_temp': 60.0,
       'min_temp': 35.0,
       'operation_list': list([
@@ -72060,7 +72060,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.vloerverwarming',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -72355,7 +72355,7 @@
 # name: test_minimal_data[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -72407,7 +72407,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -72458,7 +72458,7 @@
 # name: test_minimal_data[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -73503,7 +73503,7 @@
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
+      'friendly_name': 'Altherma Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -73560,7 +73560,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -73619,7 +73619,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -73678,7 +73678,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -73737,7 +73737,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -73790,7 +73790,7 @@
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -73847,7 +73847,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -73987,7 +73987,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
@@ -74013,7 +74013,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 53.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank',
+      'friendly_name': 'Altherma',
       'max_temp': None,
       'min_temp': None,
       'operation_list': list([
@@ -79420,7 +79420,7 @@
     'domain': 'water_heater',
     'entity_category': None,
     'entity_id': 'water_heater.altherma',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -1,8 +1,9 @@
 # serializer version: 1
 # name: test_altherma3m[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20,6 +21,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -50,8 +52,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69,6 +72,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -100,8 +104,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -119,6 +124,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -150,8 +156,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -169,6 +176,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -199,8 +207,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -218,6 +227,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -249,8 +259,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -268,6 +279,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -298,8 +310,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -317,6 +330,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -348,8 +362,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -367,6 +382,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -398,8 +414,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -417,6 +434,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -447,8 +465,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -466,6 +485,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -497,8 +517,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -516,6 +537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -546,8 +568,9 @@
 # ---
 # name: test_altherma3m[binary_sensor.altherma_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -565,6 +588,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -595,8 +619,9 @@
 # ---
 # name: test_altherma3m[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -614,6 +639,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -644,8 +670,9 @@
 # ---
 # name: test_altherma3m[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -668,18 +695,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -719,8 +747,9 @@
 # ---
 # name: test_altherma3m[select.altherma_domestichotwatertank_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -742,6 +771,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -775,8 +805,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -794,6 +825,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -824,8 +856,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -843,6 +876,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -873,8 +907,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -894,6 +929,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -930,8 +966,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -951,6 +988,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -982,13 +1020,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '462',
+    'state': '0',
   })
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1008,6 +1047,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1044,8 +1084,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1065,6 +1106,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1101,8 +1143,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1122,6 +1165,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -1158,8 +1202,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1179,6 +1224,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -1215,8 +1261,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1234,6 +1281,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1264,8 +1312,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1283,6 +1332,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1313,8 +1363,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1332,6 +1383,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1362,8 +1414,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1383,6 +1436,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1419,8 +1473,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1440,6 +1495,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1471,13 +1527,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '81',
+    'state': '0',
   })
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1497,6 +1554,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1533,8 +1591,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1554,6 +1613,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1590,8 +1650,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1609,6 +1670,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1639,8 +1701,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1660,6 +1723,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -1696,8 +1760,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1715,6 +1780,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1745,8 +1811,9 @@
 # ---
 # name: test_altherma3m[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1766,6 +1833,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1797,8 +1865,9 @@
 # ---
 # name: test_altherma3m[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 50.0,
@@ -1824,6 +1893,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1842,7 +1912,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 50.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -1867,8 +1937,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1886,6 +1957,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -1916,8 +1988,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1935,6 +2008,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -1966,8 +2040,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -1985,6 +2060,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2016,8 +2092,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2035,6 +2112,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2065,8 +2143,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2084,6 +2163,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2115,8 +2195,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2134,6 +2215,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2164,8 +2246,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2183,6 +2266,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2214,8 +2298,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2233,6 +2318,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2264,8 +2350,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2283,6 +2370,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2313,8 +2401,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2332,6 +2421,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2363,8 +2453,9 @@
 # ---
 # name: test_altherma[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2382,6 +2473,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2412,8 +2504,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2431,6 +2524,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2461,8 +2555,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2480,6 +2575,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2510,8 +2606,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2529,6 +2626,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2560,8 +2658,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2579,6 +2678,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2610,8 +2710,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2629,6 +2730,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2660,8 +2762,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2679,6 +2782,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2710,8 +2814,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2729,6 +2834,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2759,8 +2865,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2778,6 +2885,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2808,8 +2916,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2827,6 +2936,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2857,8 +2967,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2876,6 +2987,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -2907,8 +3019,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2926,6 +3039,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -2956,8 +3070,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -2975,6 +3090,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3006,8 +3122,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3025,6 +3142,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3056,8 +3174,9 @@
 # ---
 # name: test_altherma[binary_sensor.johnny_maaike_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3075,6 +3194,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3106,8 +3226,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3125,6 +3246,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3155,8 +3277,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3174,6 +3297,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3204,8 +3328,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3223,6 +3348,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3254,8 +3380,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3273,6 +3400,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3304,8 +3432,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3323,6 +3452,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3354,8 +3484,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3373,6 +3504,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3404,8 +3536,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3423,6 +3556,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3453,8 +3587,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3472,6 +3607,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3502,8 +3638,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3521,6 +3658,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3551,8 +3689,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3570,6 +3709,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3601,8 +3741,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3620,6 +3761,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3650,8 +3792,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3669,6 +3812,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3700,8 +3844,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3719,6 +3864,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3750,8 +3896,9 @@
 # ---
 # name: test_altherma[binary_sensor.linde_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3769,6 +3916,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3800,8 +3948,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3819,6 +3968,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3849,8 +3999,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3868,6 +4019,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -3898,8 +4050,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3917,6 +4070,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3948,8 +4102,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -3967,6 +4122,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -3998,8 +4154,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4017,6 +4174,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4048,8 +4206,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4067,6 +4226,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4098,8 +4258,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4117,6 +4278,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4147,8 +4309,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4166,6 +4329,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4196,8 +4360,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4215,6 +4380,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4245,8 +4411,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4264,6 +4431,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4295,8 +4463,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4314,6 +4483,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4344,8 +4514,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4363,6 +4534,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4394,8 +4566,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4413,6 +4586,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4444,8 +4618,9 @@
 # ---
 # name: test_altherma[binary_sensor.sanne_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4463,6 +4638,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4494,8 +4670,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4513,6 +4690,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4543,8 +4721,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4562,6 +4741,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4592,8 +4772,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4611,6 +4792,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4642,8 +4824,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4661,6 +4844,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4692,8 +4876,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4711,6 +4896,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4742,8 +4928,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4761,6 +4948,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4792,8 +4980,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4811,6 +5000,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4841,8 +5031,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4860,6 +5051,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4890,8 +5082,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4909,6 +5102,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -4939,8 +5133,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -4958,6 +5153,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -4989,8 +5185,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5008,6 +5205,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5038,8 +5236,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5057,6 +5256,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -5088,8 +5288,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5107,6 +5308,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -5138,8 +5340,9 @@
 # ---
 # name: test_altherma[binary_sensor.werkkamer_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5157,6 +5360,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -5188,8 +5392,9 @@
 # ---
 # name: test_altherma[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5207,6 +5412,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5237,8 +5443,9 @@
 # ---
 # name: test_altherma[button.johnny_maaike_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5256,6 +5463,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5286,8 +5494,9 @@
 # ---
 # name: test_altherma[button.linde_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5305,6 +5514,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5335,8 +5545,9 @@
 # ---
 # name: test_altherma[button.sanne_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5354,6 +5565,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5384,8 +5596,9 @@
 # ---
 # name: test_altherma[button.werkkamer_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -5403,6 +5616,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -5433,8 +5647,9 @@
 # ---
 # name: test_altherma[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -5458,18 +5673,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -5509,8 +5725,9 @@
 # ---
 # name: test_altherma[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -5535,18 +5752,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -5588,8 +5806,9 @@
 # ---
 # name: test_altherma[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -5614,18 +5833,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -5667,8 +5887,9 @@
 # ---
 # name: test_altherma[climate.johnny_maaike_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -5715,18 +5936,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.johnny_maaike_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Johnny&Maaike Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -5793,8 +6015,9 @@
 # ---
 # name: test_altherma[climate.linde_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -5841,18 +6064,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.linde_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Linde Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -5919,8 +6143,9 @@
 # ---
 # name: test_altherma[climate.sanne_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -5967,18 +6192,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.sanne_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Sanne Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -6045,8 +6271,9 @@
 # ---
 # name: test_altherma[climate.werkkamer_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -6093,18 +6320,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.werkkamer_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Werkkamer Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -6171,8 +6399,9 @@
 # ---
 # name: test_altherma[select.altherma_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -6195,6 +6424,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6229,8 +6459,9 @@
 # ---
 # name: test_altherma[select.johnny_maaike_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -6255,6 +6486,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6291,8 +6523,9 @@
 # ---
 # name: test_altherma[select.linde_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -6317,6 +6550,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6353,8 +6587,9 @@
 # ---
 # name: test_altherma[select.sanne_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -6379,6 +6614,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6415,8 +6651,9 @@
 # ---
 # name: test_altherma[select.werkkamer_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -6441,6 +6678,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6477,8 +6715,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -6496,6 +6735,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6526,8 +6766,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6547,6 +6788,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6583,8 +6825,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6604,6 +6847,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6640,8 +6884,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6661,6 +6906,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6697,8 +6943,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6718,6 +6965,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6754,8 +7002,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -6773,6 +7022,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -6803,8 +7053,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6824,6 +7075,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6860,8 +7112,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6881,6 +7134,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6912,13 +7166,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '457',
+    'state': '157',
   })
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6938,6 +7193,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -6974,8 +7230,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -6995,6 +7252,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7031,8 +7289,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7052,6 +7311,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -7088,8 +7348,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7109,6 +7370,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -7145,8 +7407,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7166,6 +7429,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -7202,8 +7466,9 @@
 # ---
 # name: test_altherma[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7221,6 +7486,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7251,8 +7517,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7270,6 +7537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7300,8 +7568,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -7321,6 +7590,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7357,8 +7627,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -7378,6 +7649,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7409,13 +7681,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '120',
+    'state': '93',
   })
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -7435,6 +7708,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7471,8 +7745,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -7492,6 +7767,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7528,8 +7804,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7547,6 +7824,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7577,8 +7855,9 @@
 # ---
 # name: test_altherma[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7598,6 +7877,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -7634,8 +7914,9 @@
 # ---
 # name: test_altherma[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7653,6 +7934,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7683,8 +7965,9 @@
 # ---
 # name: test_altherma[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7704,6 +7987,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7735,8 +8019,9 @@
 # ---
 # name: test_altherma[sensor.altherma_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7754,6 +8039,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7784,8 +8070,9 @@
 # ---
 # name: test_altherma[sensor.altherma_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7803,6 +8090,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7833,8 +8121,9 @@
 # ---
 # name: test_altherma[sensor.altherma_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -7854,6 +8143,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -7887,8 +8177,9 @@
 # ---
 # name: test_altherma[sensor.altherma_userinterface_date_time-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -7906,6 +8197,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Date/time',
     'options': dict({
     }),
     'original_device_class': None,
@@ -7936,8 +8228,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -7957,6 +8250,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -7993,8 +8287,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8014,6 +8309,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8045,13 +8341,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '2.9',
   })
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8071,6 +8368,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8107,8 +8405,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8128,6 +8427,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8164,8 +8464,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8183,6 +8484,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8213,8 +8515,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8234,6 +8537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8270,8 +8574,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8291,6 +8596,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8322,13 +8628,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.7',
+    'state': '0.7',
   })
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8348,6 +8655,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8384,8 +8692,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -8405,6 +8714,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -8441,8 +8751,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -8462,6 +8773,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -8498,8 +8810,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -8519,6 +8832,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -8555,8 +8869,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8574,6 +8889,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8604,8 +8920,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -8625,6 +8942,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8656,8 +8974,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8675,6 +8994,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8705,8 +9025,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8724,6 +9045,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8754,8 +9076,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8773,6 +9096,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8803,8 +9127,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8822,6 +9147,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8852,8 +9178,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -8873,6 +9200,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -8906,8 +9234,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8925,6 +9254,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -8955,8 +9285,9 @@
 # ---
 # name: test_altherma[sensor.johnny_maaike_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -8974,6 +9305,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9004,8 +9336,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9025,6 +9358,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9061,8 +9395,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9082,6 +9417,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9118,8 +9454,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9139,6 +9476,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9175,8 +9513,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9196,6 +9535,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9232,8 +9572,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9251,6 +9592,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9281,8 +9623,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9302,6 +9645,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9338,8 +9682,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9359,6 +9704,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9390,13 +9736,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.9',
+    'state': '3.6',
   })
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9416,6 +9763,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9452,8 +9800,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -9473,6 +9822,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -9509,8 +9859,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -9530,6 +9881,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -9566,8 +9918,9 @@
 # ---
 # name: test_altherma[sensor.linde_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -9587,6 +9940,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -9623,8 +9977,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9642,6 +9997,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9672,8 +10028,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -9693,6 +10050,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9724,8 +10082,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9743,6 +10102,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9773,8 +10133,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9792,6 +10153,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9822,8 +10184,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9841,6 +10204,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9871,8 +10235,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9890,6 +10255,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -9920,8 +10286,9 @@
 # ---
 # name: test_altherma[sensor.linde_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -9941,6 +10308,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -9974,8 +10342,9 @@
 # ---
 # name: test_altherma[sensor.linde_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -9993,6 +10362,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10023,8 +10393,9 @@
 # ---
 # name: test_altherma[sensor.linde_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10042,6 +10413,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10072,8 +10444,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10093,6 +10466,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10129,8 +10503,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10150,6 +10525,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10186,8 +10562,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10207,6 +10584,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10243,8 +10621,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10264,6 +10643,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10300,8 +10680,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10319,6 +10700,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10349,8 +10731,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10370,6 +10753,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10406,8 +10790,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10427,6 +10812,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10458,13 +10844,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '11.3',
+    'state': '3.6',
   })
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10484,6 +10871,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10520,8 +10908,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -10541,6 +10930,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -10577,8 +10967,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -10598,6 +10989,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -10634,8 +11026,9 @@
 # ---
 # name: test_altherma[sensor.sanne_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -10655,6 +11048,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -10691,8 +11085,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10710,6 +11105,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10740,8 +11136,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -10761,6 +11158,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10792,8 +11190,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10811,6 +11210,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10841,8 +11241,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10860,6 +11261,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10890,8 +11292,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10909,6 +11312,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10939,8 +11343,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -10958,6 +11363,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -10988,8 +11394,9 @@
 # ---
 # name: test_altherma[sensor.sanne_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -11009,6 +11416,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -11042,8 +11450,9 @@
 # ---
 # name: test_altherma[sensor.sanne_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11061,6 +11470,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11091,8 +11501,9 @@
 # ---
 # name: test_altherma[sensor.sanne_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11110,6 +11521,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11140,8 +11552,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11161,6 +11574,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11197,8 +11611,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11218,6 +11633,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11254,8 +11670,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11275,6 +11692,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11311,8 +11729,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11332,6 +11751,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11368,8 +11788,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11387,6 +11808,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11417,8 +11839,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11438,6 +11861,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11474,8 +11898,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11495,6 +11920,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11526,13 +11952,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '8',
+    'state': '3.5',
   })
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11552,6 +11979,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11588,8 +12016,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -11609,6 +12038,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -11645,8 +12075,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -11666,6 +12097,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -11702,8 +12134,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -11723,6 +12156,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -11759,8 +12193,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11778,6 +12213,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11808,8 +12244,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -11829,6 +12266,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11860,8 +12298,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11879,6 +12318,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11909,8 +12349,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11928,6 +12369,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -11958,8 +12400,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -11977,6 +12420,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12007,8 +12451,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12026,6 +12471,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12056,8 +12502,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -12077,6 +12524,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -12110,8 +12558,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12129,6 +12578,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12159,8 +12609,9 @@
 # ---
 # name: test_altherma[sensor.werkkamer_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12178,6 +12629,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12208,8 +12660,9 @@
 # ---
 # name: test_altherma[switch.johnny_maaike_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12227,6 +12680,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12257,8 +12711,9 @@
 # ---
 # name: test_altherma[switch.johnny_maaike_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12276,6 +12731,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12306,8 +12762,9 @@
 # ---
 # name: test_altherma[switch.linde_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12325,6 +12782,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12355,8 +12813,9 @@
 # ---
 # name: test_altherma[switch.linde_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12374,6 +12833,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12404,8 +12864,9 @@
 # ---
 # name: test_altherma[switch.sanne_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12423,6 +12884,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12453,8 +12915,9 @@
 # ---
 # name: test_altherma[switch.sanne_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12472,6 +12935,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12502,8 +12966,9 @@
 # ---
 # name: test_altherma[switch.werkkamer_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12521,6 +12986,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12551,8 +13017,9 @@
 # ---
 # name: test_altherma[switch.werkkamer_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12570,6 +13037,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12600,8 +13068,9 @@
 # ---
 # name: test_altherma[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -12627,6 +13096,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12645,7 +13115,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -12670,8 +13140,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12689,6 +13160,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12719,8 +13191,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12738,6 +13211,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -12769,8 +13243,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12788,6 +13263,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -12819,8 +13295,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12838,6 +13315,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12868,8 +13346,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12887,6 +13366,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -12918,8 +13398,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12937,6 +13418,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -12967,8 +13449,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -12986,6 +13469,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13017,8 +13501,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13036,6 +13521,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13067,8 +13553,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13086,6 +13573,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13116,8 +13604,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13135,6 +13624,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13166,8 +13656,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13185,6 +13676,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13215,8 +13707,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13234,6 +13727,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13264,8 +13758,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13283,6 +13778,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13313,8 +13809,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13332,6 +13829,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13363,8 +13861,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13382,6 +13881,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13413,8 +13913,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13432,6 +13933,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13463,8 +13965,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13482,6 +13985,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13513,8 +14017,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13532,6 +14037,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13562,8 +14068,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13581,6 +14088,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13611,8 +14119,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13630,6 +14139,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13660,8 +14170,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13679,6 +14190,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13710,8 +14222,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13729,6 +14242,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13759,8 +14273,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13778,6 +14293,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13809,8 +14325,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13828,6 +14345,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13859,8 +14377,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.johnny_maaike_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13878,6 +14397,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -13909,8 +14429,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13928,6 +14449,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -13958,8 +14480,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -13977,6 +14500,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14007,8 +14531,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14026,6 +14551,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14057,8 +14583,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14076,6 +14603,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14107,8 +14635,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14126,6 +14655,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14157,8 +14687,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14176,6 +14707,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14207,8 +14739,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14226,6 +14759,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14256,8 +14790,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14275,6 +14810,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14305,8 +14841,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14324,6 +14861,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14354,8 +14892,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14373,6 +14912,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14404,8 +14944,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14423,6 +14964,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14453,8 +14995,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14472,6 +15015,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14503,8 +15047,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14522,6 +15067,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14553,8 +15099,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.linde_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14572,6 +15119,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14603,8 +15151,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14622,6 +15171,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14652,8 +15202,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14671,6 +15222,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14701,8 +15253,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14720,6 +15273,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14751,8 +15305,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14770,6 +15325,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14801,8 +15357,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14820,6 +15377,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14851,8 +15409,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14870,6 +15429,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -14901,8 +15461,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14920,6 +15481,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14950,8 +15512,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -14969,6 +15532,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -14999,8 +15563,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15018,6 +15583,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15048,8 +15614,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15067,6 +15634,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15098,8 +15666,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15117,6 +15686,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15147,8 +15717,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15166,6 +15737,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15197,8 +15769,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15216,6 +15789,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15247,8 +15821,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.sanne_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15266,6 +15841,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15297,8 +15873,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15316,6 +15893,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15346,8 +15924,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15365,6 +15944,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15395,8 +15975,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15414,6 +15995,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15445,8 +16027,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15464,6 +16047,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15495,8 +16079,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15514,6 +16099,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15545,8 +16131,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15564,6 +16151,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15595,8 +16183,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15614,6 +16203,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15644,8 +16234,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15663,6 +16254,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15693,8 +16285,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15712,6 +16305,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15742,8 +16336,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15761,6 +16356,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15792,8 +16388,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15811,6 +16408,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -15841,8 +16439,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15860,6 +16459,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15891,8 +16491,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15910,6 +16511,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15941,8 +16543,9 @@
 # ---
 # name: test_altherma_ratelimit[binary_sensor.werkkamer_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -15960,6 +16563,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -15991,8 +16595,9 @@
 # ---
 # name: test_altherma_ratelimit[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -16010,6 +16615,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -16040,8 +16646,9 @@
 # ---
 # name: test_altherma_ratelimit[button.johnny_maaike_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -16059,6 +16666,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -16089,8 +16697,9 @@
 # ---
 # name: test_altherma_ratelimit[button.linde_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -16108,6 +16717,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -16138,8 +16748,9 @@
 # ---
 # name: test_altherma_ratelimit[button.sanne_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -16157,6 +16768,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -16187,8 +16799,9 @@
 # ---
 # name: test_altherma_ratelimit[button.werkkamer_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -16206,6 +16819,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -16236,8 +16850,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -16261,18 +16876,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16312,8 +16928,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -16338,18 +16955,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16391,8 +17009,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -16417,18 +17036,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16470,8 +17090,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.johnny_maaike_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -16518,18 +17139,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.johnny_maaike_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Johnny&Maaike Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16596,8 +17218,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.linde_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -16644,18 +17267,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.linde_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Linde Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16722,8 +17346,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.sanne_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -16770,18 +17395,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.sanne_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Sanne Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16848,8 +17474,9 @@
 # ---
 # name: test_altherma_ratelimit[climate.werkkamer_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -16896,18 +17523,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.werkkamer_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Werkkamer Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -16974,8 +17602,9 @@
 # ---
 # name: test_altherma_ratelimit[select.altherma_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -16998,6 +17627,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17032,8 +17662,9 @@
 # ---
 # name: test_altherma_ratelimit[select.johnny_maaike_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -17058,6 +17689,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17094,8 +17726,9 @@
 # ---
 # name: test_altherma_ratelimit[select.linde_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -17120,6 +17753,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17156,8 +17790,9 @@
 # ---
 # name: test_altherma_ratelimit[select.sanne_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -17182,6 +17817,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17218,8 +17854,9 @@
 # ---
 # name: test_altherma_ratelimit[select.werkkamer_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -17244,6 +17881,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17280,8 +17918,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -17299,6 +17938,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17329,8 +17969,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17350,6 +17991,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17386,8 +18028,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17407,6 +18050,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17443,8 +18087,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17464,6 +18109,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17500,8 +18146,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17521,6 +18168,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17557,8 +18205,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -17576,6 +18225,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -17606,8 +18256,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17627,6 +18278,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17663,8 +18315,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17684,6 +18337,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17715,13 +18369,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '457',
+    'state': '157',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17741,6 +18396,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17777,8 +18433,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -17798,6 +18455,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -17834,8 +18492,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -17855,6 +18514,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -17891,8 +18551,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -17912,6 +18573,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -17948,8 +18610,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -17969,6 +18632,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -18005,8 +18669,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18024,6 +18689,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18054,8 +18720,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18073,6 +18740,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18103,8 +18771,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18124,6 +18793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18160,8 +18830,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18181,6 +18852,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18212,13 +18884,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '120',
+    'state': '93',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18238,6 +18911,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18274,8 +18948,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18295,6 +18970,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18331,8 +19007,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18350,6 +19027,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18380,8 +19058,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -18401,6 +19080,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -18437,8 +19117,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18456,6 +19137,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18486,8 +19168,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -18507,6 +19190,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18538,8 +19222,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18557,6 +19242,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18587,8 +19273,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18606,6 +19293,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18636,8 +19324,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -18657,6 +19346,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -18690,8 +19380,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.altherma_userinterface_date_time-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18709,6 +19400,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Date/time',
     'options': dict({
     }),
     'original_device_class': None,
@@ -18739,8 +19431,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18760,6 +19453,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18796,8 +19490,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18817,6 +19512,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18848,13 +19544,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '2.9',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18874,6 +19571,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18910,8 +19608,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -18931,6 +19630,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -18967,8 +19667,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -18986,6 +19687,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19016,8 +19718,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19037,6 +19740,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19073,8 +19777,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19094,6 +19799,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19125,13 +19831,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.7',
+    'state': '0.7',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19151,6 +19858,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19187,8 +19895,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19208,6 +19917,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19244,8 +19954,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -19265,6 +19976,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -19301,8 +20013,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -19322,6 +20035,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -19358,8 +20072,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19377,6 +20092,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19407,8 +20123,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -19428,6 +20145,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19459,8 +20177,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19478,6 +20197,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19508,8 +20228,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19527,6 +20248,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19557,8 +20279,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19576,6 +20299,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19606,8 +20330,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19625,6 +20350,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19655,8 +20381,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -19676,6 +20403,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -19709,8 +20437,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19728,6 +20457,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19758,8 +20488,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.johnny_maaike_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -19777,6 +20508,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -19807,8 +20539,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19828,6 +20561,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19864,8 +20598,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19885,6 +20620,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19921,8 +20657,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19942,6 +20679,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -19978,8 +20716,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -19999,6 +20738,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20035,8 +20775,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20054,6 +20795,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20084,8 +20826,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20105,6 +20848,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20141,8 +20885,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20162,6 +20907,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20193,13 +20939,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.9',
+    'state': '3.6',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20219,6 +20966,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20255,8 +21003,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20276,6 +21025,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20312,8 +21062,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -20333,6 +21084,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -20369,8 +21121,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -20390,6 +21143,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -20426,8 +21180,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20445,6 +21200,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20475,8 +21231,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -20496,6 +21253,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20527,8 +21285,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20546,6 +21305,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20576,8 +21336,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20595,6 +21356,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20625,8 +21387,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20644,6 +21407,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20674,8 +21438,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20693,6 +21458,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20723,8 +21489,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -20744,6 +21511,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -20777,8 +21545,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20796,6 +21565,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20826,8 +21596,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.linde_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -20845,6 +21616,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -20875,8 +21647,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20896,6 +21669,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20932,8 +21706,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -20953,6 +21728,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -20989,8 +21765,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21010,6 +21787,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21046,8 +21824,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21067,6 +21846,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21103,8 +21883,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21122,6 +21903,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21152,8 +21934,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21173,6 +21956,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21209,8 +21993,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21230,6 +22015,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21261,13 +22047,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '11.3',
+    'state': '3.6',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21287,6 +22074,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21323,8 +22111,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21344,6 +22133,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -21380,8 +22170,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -21401,6 +22192,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -21437,8 +22229,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -21458,6 +22251,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -21494,8 +22288,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21513,6 +22308,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21543,8 +22339,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -21564,6 +22361,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21595,8 +22393,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21614,6 +22413,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21644,8 +22444,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21663,6 +22464,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21693,8 +22495,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21712,6 +22515,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21742,8 +22546,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21761,6 +22566,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21791,8 +22597,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -21812,6 +22619,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -21845,8 +22653,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21864,6 +22673,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21894,8 +22704,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.sanne_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -21913,6 +22724,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -21943,8 +22755,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -21964,6 +22777,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22000,8 +22814,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22021,6 +22836,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22057,8 +22873,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22078,6 +22895,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22114,8 +22932,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22135,6 +22954,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22171,8 +22991,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22190,6 +23011,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22220,8 +23042,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22241,6 +23064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22277,8 +23101,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22298,6 +23123,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22329,13 +23155,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '8',
+    'state': '3.5',
   })
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22355,6 +23182,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22391,8 +23219,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -22412,6 +23241,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -22448,8 +23278,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -22469,6 +23300,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -22505,8 +23337,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -22526,6 +23359,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -22562,8 +23396,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22581,6 +23416,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22611,8 +23447,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -22632,6 +23469,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22663,8 +23501,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22682,6 +23521,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22712,8 +23552,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22731,6 +23572,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22761,8 +23603,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22780,6 +23623,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22810,8 +23654,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22829,6 +23674,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22859,8 +23705,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -22880,6 +23727,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -22913,8 +23761,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22932,6 +23781,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -22962,8 +23812,9 @@
 # ---
 # name: test_altherma_ratelimit[sensor.werkkamer_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -22981,6 +23832,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23011,8 +23863,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.johnny_maaike_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23030,6 +23883,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23060,8 +23914,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.johnny_maaike_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23079,6 +23934,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23109,8 +23965,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.linde_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23128,6 +23985,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23158,8 +24016,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.linde_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23177,6 +24036,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23207,8 +24067,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.sanne_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23226,6 +24087,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23256,8 +24118,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.sanne_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23275,6 +24138,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23305,8 +24169,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.werkkamer_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23324,6 +24189,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23354,8 +24220,9 @@
 # ---
 # name: test_altherma_ratelimit[switch.werkkamer_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23373,6 +24240,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23403,8 +24271,9 @@
 # ---
 # name: test_altherma_ratelimit[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -23430,6 +24299,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23448,7 +24318,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -23473,8 +24343,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23492,6 +24363,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23522,8 +24394,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23541,6 +24414,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23572,8 +24446,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23591,6 +24466,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23622,8 +24498,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23641,6 +24518,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23671,8 +24549,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23690,6 +24569,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23721,8 +24601,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23740,6 +24621,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23770,8 +24652,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23789,6 +24672,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23820,8 +24704,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23839,6 +24724,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23870,8 +24756,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23889,6 +24776,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -23919,8 +24807,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23938,6 +24827,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -23969,8 +24859,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -23988,6 +24879,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24018,8 +24910,9 @@
 # ---
 # name: test_altherma_schedule[binary_sensor.altherma_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -24037,6 +24930,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24067,8 +24961,9 @@
 # ---
 # name: test_altherma_schedule[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -24086,6 +24981,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24116,8 +25012,9 @@
 # ---
 # name: test_altherma_schedule[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -24142,18 +25039,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -24195,8 +25093,9 @@
 # ---
 # name: test_altherma_schedule[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -24220,18 +25119,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -24271,8 +25171,9 @@
 # ---
 # name: test_altherma_schedule[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -24297,18 +25198,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -24350,8 +25252,9 @@
 # ---
 # name: test_altherma_schedule[select.altherma_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -24376,6 +25279,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24412,8 +25316,9 @@
 # ---
 # name: test_altherma_schedule[select.altherma_domestichotwatertank_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -24435,6 +25340,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24468,8 +25374,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -24487,6 +25394,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24517,8 +25425,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24538,6 +25447,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24574,8 +25484,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24595,6 +25506,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24631,8 +25543,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24652,6 +25565,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24688,8 +25602,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24709,6 +25624,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24745,8 +25661,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -24764,6 +25681,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -24794,8 +25712,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24815,6 +25734,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24851,8 +25771,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24872,6 +25793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24903,13 +25825,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '618',
+    'state': '19',
   })
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24929,6 +25852,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -24965,8 +25889,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -24986,6 +25911,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -25022,8 +25948,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -25043,6 +25970,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -25079,8 +26007,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -25100,6 +26029,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -25136,8 +26066,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -25157,6 +26088,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -25193,8 +26125,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25212,6 +26145,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25242,8 +26176,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25261,6 +26196,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25291,8 +26227,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25310,6 +26247,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25340,8 +26278,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -25361,6 +26300,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -25397,8 +26337,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -25418,6 +26359,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -25449,13 +26391,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '140',
+    'state': '46',
   })
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -25475,6 +26418,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -25511,8 +26455,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -25532,6 +26477,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -25568,8 +26514,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25587,6 +26534,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25617,8 +26565,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -25638,6 +26587,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -25674,8 +26624,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25693,6 +26644,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25723,8 +26675,9 @@
 # ---
 # name: test_altherma_schedule[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -25744,6 +26697,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25775,8 +26729,9 @@
 # ---
 # name: test_altherma_schedule[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -25802,6 +26757,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25820,7 +26776,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 51.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -25845,8 +26801,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25864,6 +26821,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -25894,8 +26852,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25913,6 +26872,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -25944,8 +26904,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -25963,6 +26924,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -25994,8 +26956,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26013,6 +26976,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26044,8 +27008,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26063,6 +27028,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -26093,8 +27059,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26112,6 +27079,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26143,8 +27111,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26162,6 +27131,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26193,8 +27163,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26212,6 +27183,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26243,8 +27215,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_1_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26262,6 +27235,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26293,8 +27267,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26312,6 +27287,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -26342,8 +27318,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26361,6 +27338,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26392,8 +27370,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26411,6 +27390,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26442,8 +27422,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26461,6 +27442,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26492,8 +27474,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26511,6 +27494,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -26541,8 +27525,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26560,6 +27545,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26591,8 +27577,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26610,6 +27597,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26641,8 +27629,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26660,6 +27649,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26691,8 +27681,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_2_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26710,6 +27701,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26741,8 +27733,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26760,6 +27753,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -26790,8 +27784,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26809,6 +27804,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26840,8 +27836,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26859,6 +27856,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26890,8 +27888,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26909,6 +27908,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -26940,8 +27940,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -26959,6 +27960,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -26989,8 +27991,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27008,6 +28011,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27039,8 +28043,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27058,6 +28063,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27089,8 +28095,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27108,6 +28115,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27139,8 +28147,9 @@
 # ---
 # name: test_button[binary_sensor.bedroom_3_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27158,6 +28167,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27189,8 +28199,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27208,6 +28219,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -27238,8 +28250,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27257,6 +28270,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27288,8 +28302,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27307,6 +28322,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27338,8 +28354,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27357,6 +28374,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27388,8 +28406,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27407,6 +28426,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -27437,8 +28457,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27456,6 +28477,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27487,8 +28509,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27506,6 +28529,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27537,8 +28561,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27556,6 +28581,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27587,8 +28613,9 @@
 # ---
 # name: test_button[binary_sensor.kitchen_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27606,6 +28633,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27637,8 +28665,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27656,6 +28685,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -27686,8 +28716,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27705,6 +28736,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27736,8 +28768,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27755,6 +28788,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27786,8 +28820,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27805,6 +28840,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27836,8 +28872,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27855,6 +28892,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -27885,8 +28923,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27904,6 +28943,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27935,8 +28975,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -27954,6 +28995,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -27985,8 +29027,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28004,6 +29047,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28035,8 +29079,9 @@
 # ---
 # name: test_button[binary_sensor.lounge_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28054,6 +29099,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28085,8 +29131,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28104,6 +29151,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -28134,8 +29182,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28153,6 +29202,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28184,8 +29234,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28203,6 +29254,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28234,8 +29286,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28253,6 +29306,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28284,8 +29338,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28303,6 +29358,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -28333,8 +29389,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28352,6 +29409,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28383,8 +29441,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28402,6 +29461,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28433,8 +29493,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28452,6 +29513,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28483,8 +29545,9 @@
 # ---
 # name: test_button[binary_sensor.master_bathroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28502,6 +29565,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28533,8 +29597,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28552,6 +29617,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -28582,8 +29648,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28601,6 +29668,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28632,8 +29700,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28651,6 +29720,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28682,8 +29752,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28701,6 +29772,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28732,8 +29804,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28751,6 +29824,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -28781,8 +29855,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28800,6 +29875,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28831,8 +29907,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28850,6 +29927,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28881,8 +29959,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28900,6 +29979,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28931,8 +30011,9 @@
 # ---
 # name: test_button[binary_sensor.master_bedroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -28950,6 +30031,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -28981,8 +30063,9 @@
 # ---
 # name: test_button[button.bedroom_1_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29000,6 +30083,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29030,8 +30114,9 @@
 # ---
 # name: test_button[button.bedroom_2_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29049,6 +30134,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29079,8 +30165,9 @@
 # ---
 # name: test_button[button.bedroom_3_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29098,6 +30185,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29128,8 +30216,9 @@
 # ---
 # name: test_button[button.kitchen_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29147,6 +30236,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29177,8 +30267,9 @@
 # ---
 # name: test_button[button.lounge_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29196,6 +30287,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29226,8 +30318,9 @@
 # ---
 # name: test_button[button.master_bathroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29245,6 +30338,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29275,8 +30369,9 @@
 # ---
 # name: test_button[button.master_bedroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -29294,6 +30389,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29324,8 +30420,9 @@
 # ---
 # name: test_button[climate.bedroom_1_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29349,18 +30446,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_1_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 1 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29400,8 +30498,9 @@
 # ---
 # name: test_button[climate.bedroom_2_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29425,18 +30524,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_2_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 2 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29476,8 +30576,9 @@
 # ---
 # name: test_button[climate.bedroom_3_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29506,18 +30607,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_3_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 3 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29563,8 +30665,9 @@
 # ---
 # name: test_button[climate.kitchen_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29588,18 +30691,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.kitchen_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Kitchen Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29639,8 +30743,9 @@
 # ---
 # name: test_button[climate.lounge_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29664,18 +30769,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.lounge_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Lounge Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29715,8 +30821,9 @@
 # ---
 # name: test_button[climate.master_bathroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29740,18 +30847,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bathroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bathroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29791,8 +30899,9 @@
 # ---
 # name: test_button[climate.master_bedroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -29816,18 +30925,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bedroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bedroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -29867,8 +30977,9 @@
 # ---
 # name: test_button[select.bedroom_1_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -29893,6 +31004,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29929,8 +31041,9 @@
 # ---
 # name: test_button[select.bedroom_2_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -29955,6 +31068,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -29991,8 +31105,9 @@
 # ---
 # name: test_button[select.bedroom_3_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -30015,6 +31130,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30049,8 +31165,9 @@
 # ---
 # name: test_button[select.kitchen_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -30075,6 +31192,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30111,8 +31229,9 @@
 # ---
 # name: test_button[select.lounge_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -30137,6 +31256,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30173,8 +31293,9 @@
 # ---
 # name: test_button[select.master_bathroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -30199,6 +31320,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30235,8 +31357,9 @@
 # ---
 # name: test_button[select.master_bedroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -30261,6 +31384,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30297,8 +31421,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30316,6 +31441,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30346,8 +31472,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -30367,6 +31494,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -30403,8 +31531,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30422,6 +31551,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30452,8 +31582,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30471,6 +31602,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30501,8 +31633,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -30522,6 +31655,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30553,8 +31687,9 @@
 # ---
 # name: test_button[sensor.bedroom_1_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30572,6 +31707,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30602,8 +31738,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30621,6 +31758,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30651,8 +31789,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -30672,6 +31811,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -30708,8 +31848,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30727,6 +31868,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30757,8 +31899,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30776,6 +31919,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30806,8 +31950,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -30827,6 +31972,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30858,8 +32004,9 @@
 # ---
 # name: test_button[sensor.bedroom_2_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30877,6 +32024,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30907,8 +32055,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -30926,6 +32075,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -30956,8 +32106,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -30977,6 +32128,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31013,8 +32165,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31032,6 +32185,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31062,8 +32216,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31081,6 +32236,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31111,8 +32267,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31132,6 +32289,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31163,8 +32321,9 @@
 # ---
 # name: test_button[sensor.bedroom_3_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31182,6 +32341,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31212,8 +32372,9 @@
 # ---
 # name: test_button[sensor.kitchen_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31231,6 +32392,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31261,8 +32423,9 @@
 # ---
 # name: test_button[sensor.kitchen_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31282,6 +32445,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31318,8 +32482,9 @@
 # ---
 # name: test_button[sensor.kitchen_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31337,6 +32502,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31367,8 +32533,9 @@
 # ---
 # name: test_button[sensor.kitchen_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31386,6 +32553,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31416,8 +32584,9 @@
 # ---
 # name: test_button[sensor.kitchen_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31437,6 +32606,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31468,8 +32638,9 @@
 # ---
 # name: test_button[sensor.kitchen_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31487,6 +32658,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31517,8 +32689,9 @@
 # ---
 # name: test_button[sensor.lounge_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31536,6 +32709,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31566,8 +32740,9 @@
 # ---
 # name: test_button[sensor.lounge_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31587,6 +32762,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31623,8 +32799,9 @@
 # ---
 # name: test_button[sensor.lounge_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31642,6 +32819,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31672,8 +32850,9 @@
 # ---
 # name: test_button[sensor.lounge_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31691,6 +32870,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31721,8 +32901,9 @@
 # ---
 # name: test_button[sensor.lounge_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31742,6 +32923,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31773,8 +32955,9 @@
 # ---
 # name: test_button[sensor.lounge_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31792,6 +32975,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31822,8 +33006,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31841,6 +33026,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31871,8 +33057,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -31892,6 +33079,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -31928,8 +33116,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31947,6 +33136,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -31977,8 +33167,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -31996,6 +33187,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32026,8 +33218,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -32047,6 +33240,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32078,8 +33272,9 @@
 # ---
 # name: test_button[sensor.master_bathroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32097,6 +33292,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32127,8 +33323,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32146,6 +33343,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32176,8 +33374,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -32197,6 +33396,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -32233,8 +33433,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32252,6 +33453,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32282,8 +33484,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32301,6 +33504,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32331,8 +33535,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -32352,6 +33557,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32383,8 +33589,9 @@
 # ---
 # name: test_button[sensor.master_bedroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32402,6 +33609,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32432,8 +33640,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32451,6 +33660,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32481,8 +33691,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32500,6 +33711,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32531,8 +33743,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32550,6 +33763,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32581,8 +33795,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32600,6 +33815,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32630,8 +33846,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32649,6 +33866,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32680,8 +33898,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32699,6 +33918,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32729,8 +33949,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32748,6 +33969,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32779,8 +34001,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32798,6 +34021,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32829,8 +34053,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32848,6 +34073,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32878,8 +34104,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32897,6 +34124,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -32928,8 +34156,9 @@
 # ---
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32947,6 +34176,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -32977,8 +34207,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -32996,6 +34227,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33026,8 +34258,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33045,6 +34278,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33075,8 +34309,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33094,6 +34329,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33125,8 +34361,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33144,6 +34381,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33175,8 +34413,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33194,6 +34433,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33225,8 +34465,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33244,6 +34485,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33275,8 +34517,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33294,6 +34537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33324,8 +34568,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33343,6 +34588,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33373,8 +34619,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33392,6 +34639,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33422,8 +34670,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33441,6 +34690,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33472,8 +34722,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33491,6 +34742,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33521,8 +34773,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33540,6 +34793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33571,8 +34825,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33590,6 +34845,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33621,8 +34877,9 @@
 # ---
 # name: test_climate[binary_sensor.johnny_maaike_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33640,6 +34897,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33671,8 +34929,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33690,6 +34949,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33720,8 +34980,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33739,6 +35000,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -33769,8 +35031,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33788,6 +35051,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33819,8 +35083,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33838,6 +35103,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33869,8 +35135,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33888,6 +35155,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33919,8 +35187,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33938,6 +35207,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -33969,8 +35239,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -33988,6 +35259,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34018,8 +35290,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34037,6 +35310,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34067,8 +35341,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34086,6 +35361,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34116,8 +35392,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34135,6 +35412,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34166,8 +35444,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34185,6 +35464,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34215,8 +35495,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34234,6 +35515,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34265,8 +35547,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34284,6 +35567,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34315,8 +35599,9 @@
 # ---
 # name: test_climate[binary_sensor.linde_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34334,6 +35619,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34365,8 +35651,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34384,6 +35671,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34414,8 +35702,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34433,6 +35722,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34463,8 +35753,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34482,6 +35773,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34513,8 +35805,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34532,6 +35825,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34563,8 +35857,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34582,6 +35877,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34613,8 +35909,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34632,6 +35929,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34663,8 +35961,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34682,6 +35981,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34712,8 +36012,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34731,6 +36032,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34761,8 +36063,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34780,6 +36083,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34810,8 +36114,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34829,6 +36134,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34860,8 +36166,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34879,6 +36186,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -34909,8 +36217,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34928,6 +36237,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -34959,8 +36269,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -34978,6 +36289,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35009,8 +36321,9 @@
 # ---
 # name: test_climate[binary_sensor.sanne_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35028,6 +36341,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35059,8 +36373,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35078,6 +36393,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35108,8 +36424,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35127,6 +36444,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35157,8 +36475,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35176,6 +36495,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35207,8 +36527,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35226,6 +36547,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35257,8 +36579,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35276,6 +36599,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35307,8 +36631,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35326,6 +36651,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35357,8 +36683,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35376,6 +36703,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35406,8 +36734,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35425,6 +36754,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35455,8 +36785,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35474,6 +36805,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35504,8 +36836,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35523,6 +36856,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35554,8 +36888,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35573,6 +36908,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35603,8 +36939,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35622,6 +36959,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35653,8 +36991,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35672,6 +37011,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35703,8 +37043,9 @@
 # ---
 # name: test_climate[binary_sensor.werkkamer_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35722,6 +37063,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -35753,8 +37095,9 @@
 # ---
 # name: test_climate[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35772,6 +37115,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35789,7 +37133,7 @@
 # name: test_climate[button.altherma_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Refresh',
+      'friendly_name': 'Sanne Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -35802,8 +37146,9 @@
 # ---
 # name: test_climate[button.johnny_maaike_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35821,6 +37166,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35838,7 +37184,7 @@
 # name: test_climate[button.johnny_maaike_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Johnny&Maaike Refresh',
+      'friendly_name': 'Sanne Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -35851,8 +37197,9 @@
 # ---
 # name: test_climate[button.linde_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35870,6 +37217,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35887,7 +37235,7 @@
 # name: test_climate[button.linde_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Linde Refresh',
+      'friendly_name': 'Sanne Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -35900,8 +37248,9 @@
 # ---
 # name: test_climate[button.sanne_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35919,6 +37268,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35949,8 +37299,9 @@
 # ---
 # name: test_climate[button.werkkamer_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -35968,6 +37319,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -35985,7 +37337,7 @@
 # name: test_climate[button.werkkamer_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Werkkamer Refresh',
+      'friendly_name': 'Sanne Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -35998,8 +37350,9 @@
 # ---
 # name: test_climate[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -36023,18 +37376,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36048,7 +37402,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27,
-      'friendly_name': 'Altherma Leaving Water Offset',
+      'friendly_name': 'Sanne Leaving Water Offset',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -36074,8 +37428,9 @@
 # ---
 # name: test_climate[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -36100,18 +37455,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36125,7 +37481,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27,
-      'friendly_name': 'Altherma Leaving Water Temperature',
+      'friendly_name': 'Sanne Leaving Water Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -36153,8 +37509,9 @@
 # ---
 # name: test_climate[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -36179,18 +37536,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36204,7 +37562,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21,
-      'friendly_name': 'Altherma Room Temperature',
+      'friendly_name': 'Sanne Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -36232,8 +37590,9 @@
 # ---
 # name: test_climate[climate.johnny_maaike_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -36280,18 +37639,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.johnny_maaike_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Johnny&Maaike Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36315,7 +37675,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Johnny&Maaike Room Temperature',
+      'friendly_name': 'Sanne Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -36358,8 +37718,9 @@
 # ---
 # name: test_climate[climate.linde_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -36406,18 +37767,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.linde_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Linde Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36441,7 +37803,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Linde Room Temperature',
+      'friendly_name': 'Sanne Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -36484,8 +37846,9 @@
 # ---
 # name: test_climate[climate.sanne_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -36532,18 +37895,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.sanne_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Sanne Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36610,8 +37974,9 @@
 # ---
 # name: test_climate[climate.werkkamer_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -36658,18 +38023,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.werkkamer_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Werkkamer Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36693,7 +38059,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Werkkamer Room Temperature',
+      'friendly_name': 'Sanne Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -36736,8 +38102,9 @@
 # ---
 # name: test_climate[select.altherma_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -36760,6 +38127,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -36794,8 +38162,9 @@
 # ---
 # name: test_climate[select.johnny_maaike_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -36820,6 +38189,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -36856,8 +38226,9 @@
 # ---
 # name: test_climate[select.linde_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -36882,6 +38253,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -36918,8 +38290,9 @@
 # ---
 # name: test_climate[select.sanne_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -36944,6 +38317,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -36980,8 +38354,9 @@
 # ---
 # name: test_climate[select.werkkamer_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -37006,6 +38381,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -37042,8 +38418,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -37061,6 +38438,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -37091,8 +38469,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37112,6 +38491,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37148,8 +38528,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37169,6 +38550,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37205,8 +38587,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37226,6 +38609,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37262,8 +38646,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37283,6 +38668,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37319,8 +38705,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -37338,6 +38725,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -37368,8 +38756,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37389,6 +38778,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37425,8 +38815,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37446,6 +38837,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37477,13 +38869,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '457',
+    'state': '157',
   })
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37503,6 +38896,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37539,8 +38933,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37560,6 +38955,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37596,8 +38992,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -37617,6 +39014,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -37653,8 +39051,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -37674,6 +39073,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -37710,8 +39110,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -37731,6 +39132,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -37767,8 +39169,9 @@
 # ---
 # name: test_climate[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -37786,6 +39189,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -37816,8 +39220,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -37835,6 +39240,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -37865,8 +39271,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37886,6 +39293,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37922,8 +39330,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -37943,6 +39352,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -37974,13 +39384,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '120',
+    'state': '93',
   })
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38000,6 +39411,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38036,8 +39448,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38057,6 +39470,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38093,8 +39507,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38112,6 +39527,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38142,8 +39558,9 @@
 # ---
 # name: test_climate[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -38163,6 +39580,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -38199,8 +39617,9 @@
 # ---
 # name: test_climate[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38218,6 +39637,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38248,8 +39668,9 @@
 # ---
 # name: test_climate[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -38269,6 +39690,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38300,8 +39722,9 @@
 # ---
 # name: test_climate[sensor.altherma_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38319,6 +39742,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38349,8 +39773,9 @@
 # ---
 # name: test_climate[sensor.altherma_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38368,6 +39793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38398,8 +39824,9 @@
 # ---
 # name: test_climate[sensor.altherma_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -38419,6 +39846,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -38452,8 +39880,9 @@
 # ---
 # name: test_climate[sensor.altherma_userinterface_date_time-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38471,6 +39900,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Date/time',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38501,8 +39931,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38522,6 +39953,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38558,8 +39990,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38579,6 +40012,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38610,13 +40044,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '2.9',
   })
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38636,6 +40071,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38672,8 +40108,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38693,6 +40130,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38729,8 +40167,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -38748,6 +40187,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -38778,8 +40218,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38799,6 +40240,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38835,8 +40277,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38856,6 +40299,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38887,13 +40331,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.7',
+    'state': '0.7',
   })
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38913,6 +40358,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -38949,8 +40395,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -38970,6 +40417,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39006,8 +40454,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -39027,6 +40476,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -39063,8 +40513,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -39084,6 +40535,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -39120,8 +40572,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39139,6 +40592,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39169,8 +40623,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -39190,6 +40645,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39221,8 +40677,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39240,6 +40697,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39270,8 +40728,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39289,6 +40748,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39319,8 +40779,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39338,6 +40799,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39368,8 +40830,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39387,6 +40850,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39417,8 +40881,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -39438,6 +40903,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -39471,8 +40937,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39490,6 +40957,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39520,8 +40988,9 @@
 # ---
 # name: test_climate[sensor.johnny_maaike_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39539,6 +41008,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39569,8 +41039,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39590,6 +41061,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39626,8 +41098,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39647,6 +41120,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39683,8 +41157,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39704,6 +41179,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39740,8 +41216,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39761,6 +41238,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39797,8 +41275,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -39816,6 +41295,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -39846,8 +41326,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39867,6 +41348,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39903,8 +41385,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39924,6 +41407,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -39955,13 +41439,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.9',
+    'state': '3.6',
   })
 # ---
 # name: test_climate[sensor.linde_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -39981,6 +41466,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40017,8 +41503,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40038,6 +41525,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40074,8 +41562,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -40095,6 +41584,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -40131,8 +41621,9 @@
 # ---
 # name: test_climate[sensor.linde_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -40152,6 +41643,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -40188,8 +41680,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40207,6 +41700,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40237,8 +41731,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -40258,6 +41753,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40289,8 +41785,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40308,6 +41805,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40338,8 +41836,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40357,6 +41856,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40387,8 +41887,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40406,6 +41907,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40436,8 +41938,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40455,6 +41958,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40485,8 +41989,9 @@
 # ---
 # name: test_climate[sensor.linde_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -40506,6 +42011,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -40539,8 +42045,9 @@
 # ---
 # name: test_climate[sensor.linde_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40558,6 +42065,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40588,8 +42096,9 @@
 # ---
 # name: test_climate[sensor.linde_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40607,6 +42116,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40637,8 +42147,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40658,6 +42169,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40694,8 +42206,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40715,6 +42228,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40751,8 +42265,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40772,6 +42287,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40808,8 +42324,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40829,6 +42346,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40865,8 +42383,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -40884,6 +42403,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -40914,8 +42434,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40935,6 +42456,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -40971,8 +42493,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -40992,6 +42515,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41023,13 +42547,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '11.3',
+    'state': '3.6',
   })
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41049,6 +42574,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41085,8 +42611,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41106,6 +42633,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41142,8 +42670,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -41163,6 +42692,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -41199,8 +42729,9 @@
 # ---
 # name: test_climate[sensor.sanne_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -41220,6 +42751,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -41256,8 +42788,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41275,6 +42808,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41305,8 +42839,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -41326,6 +42861,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41357,8 +42893,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41376,6 +42913,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41406,8 +42944,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41425,6 +42964,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41455,8 +42995,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41474,6 +43015,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41504,8 +43046,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41523,6 +43066,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41553,8 +43097,9 @@
 # ---
 # name: test_climate[sensor.sanne_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -41574,6 +43119,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -41607,8 +43153,9 @@
 # ---
 # name: test_climate[sensor.sanne_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41626,6 +43173,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41656,8 +43204,9 @@
 # ---
 # name: test_climate[sensor.sanne_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41675,6 +43224,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41705,8 +43255,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41726,6 +43277,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41762,8 +43314,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41783,6 +43336,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41819,8 +43373,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41840,6 +43395,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41876,8 +43432,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -41897,6 +43454,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -41933,8 +43491,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -41952,6 +43511,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -41982,8 +43542,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -42003,6 +43564,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -42039,8 +43601,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -42060,6 +43623,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -42091,13 +43655,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '8',
+    'state': '3.5',
   })
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -42117,6 +43682,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -42153,8 +43719,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -42174,6 +43741,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -42210,8 +43778,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -42231,6 +43800,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -42267,8 +43837,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -42288,6 +43859,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -42324,8 +43896,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42343,6 +43916,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42373,8 +43947,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -42394,6 +43969,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42425,8 +44001,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42444,6 +44021,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42474,8 +44052,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42493,6 +44072,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42523,8 +44103,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42542,6 +44123,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42572,8 +44154,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42591,6 +44174,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42621,8 +44205,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -42642,6 +44227,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -42675,8 +44261,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42694,6 +44281,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42724,8 +44312,9 @@
 # ---
 # name: test_climate[sensor.werkkamer_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42743,6 +44332,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42773,8 +44363,9 @@
 # ---
 # name: test_climate[switch.johnny_maaike_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42792,6 +44383,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42822,8 +44414,9 @@
 # ---
 # name: test_climate[switch.johnny_maaike_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42841,6 +44434,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42871,8 +44465,9 @@
 # ---
 # name: test_climate[switch.linde_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42890,6 +44485,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42920,8 +44516,9 @@
 # ---
 # name: test_climate[switch.linde_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42939,6 +44536,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -42969,8 +44567,9 @@
 # ---
 # name: test_climate[switch.sanne_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -42988,6 +44587,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43018,8 +44618,9 @@
 # ---
 # name: test_climate[switch.sanne_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43037,6 +44638,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43067,8 +44669,9 @@
 # ---
 # name: test_climate[switch.werkkamer_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43086,6 +44689,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43116,8 +44720,9 @@
 # ---
 # name: test_climate[switch.werkkamer_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43135,6 +44740,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43165,8 +44771,9 @@
 # ---
 # name: test_climate[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -43192,6 +44799,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43210,7 +44818,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -43235,8 +44843,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43254,6 +44863,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43284,8 +44894,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43303,6 +44914,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43334,8 +44946,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43353,6 +44966,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43384,8 +44998,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43403,6 +45018,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43434,8 +45050,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43453,6 +45070,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43483,8 +45101,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43502,6 +45121,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43532,8 +45152,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43551,6 +45172,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43582,8 +45204,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43601,6 +45224,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43632,8 +45256,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43651,6 +45276,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43682,8 +45308,9 @@
 # ---
 # name: test_climate_fixedfanmode[binary_sensor.werkkamer_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43701,6 +45328,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -43732,8 +45360,9 @@
 # ---
 # name: test_climate_fixedfanmode[button.werkkamer_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -43751,6 +45380,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43781,8 +45411,9 @@
 # ---
 # name: test_climate_fixedfanmode[climate.werkkamer_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -43828,18 +45459,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.werkkamer_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Werkkamer Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -43905,8 +45537,9 @@
 # ---
 # name: test_climate_fixedfanmode[select.werkkamer_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -43929,6 +45562,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -43963,8 +45597,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -43984,6 +45619,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44020,8 +45656,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44041,6 +45678,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44077,8 +45715,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44098,6 +45737,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44134,8 +45774,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44155,6 +45796,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44191,8 +45833,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44210,6 +45853,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44240,8 +45884,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44261,6 +45906,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44297,8 +45943,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44318,6 +45965,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44349,13 +45997,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '6',
+    'state': '0',
   })
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44375,6 +46024,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44411,8 +46061,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -44432,6 +46083,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -44468,8 +46120,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -44489,6 +46142,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -44525,8 +46179,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -44546,6 +46201,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -44582,8 +46238,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44601,6 +46258,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44631,8 +46289,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44650,6 +46309,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44680,8 +46340,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -44701,6 +46362,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44732,8 +46394,9 @@
 # ---
 # name: test_climate_fixedfanmode[sensor.werkkamer_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44751,6 +46414,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44781,8 +46445,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44800,6 +46465,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44830,8 +46496,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44849,6 +46516,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -44879,8 +46547,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44898,6 +46567,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -44929,8 +46599,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44948,6 +46619,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -44979,8 +46651,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_in_mode_conflict-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -44998,6 +46671,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in mode conflict',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45029,8 +46703,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45048,6 +46723,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45079,8 +46755,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45098,6 +46775,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45128,8 +46806,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45147,6 +46826,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45177,8 +46857,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45196,6 +46877,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45226,8 +46908,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45245,6 +46928,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45276,8 +46960,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45295,6 +46980,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45325,8 +47011,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45344,6 +47031,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45375,8 +47063,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45394,6 +47083,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45425,8 +47115,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45444,6 +47135,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45475,8 +47167,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_cool_heat_master-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45494,6 +47187,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is cool/heat master',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45524,8 +47218,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45543,6 +47238,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45573,8 +47269,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45592,6 +47289,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45623,8 +47321,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45642,6 +47341,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45673,8 +47373,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45692,6 +47393,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45723,8 +47425,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_lock_function_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45742,6 +47445,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is lock function enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45772,8 +47476,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45791,6 +47496,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45821,8 +47527,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_gateway_daylight_saving_time_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45840,6 +47547,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Daylight saving time enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45870,8 +47578,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45889,6 +47598,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -45920,8 +47630,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_gateway_led_enabled-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45939,6 +47650,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'LED enabled',
     'options': dict({
     }),
     'original_device_class': None,
@@ -45969,8 +47681,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -45988,6 +47701,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -46019,8 +47733,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -46038,6 +47753,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -46069,8 +47785,9 @@
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.woonkamer_airco_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -46088,6 +47805,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -46119,8 +47837,9 @@
 # ---
 # name: test_climate_floorheatingairflow[button.laurens_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -46138,6 +47857,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -46168,8 +47888,9 @@
 # ---
 # name: test_climate_floorheatingairflow[button.woonkamer_airco_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -46187,6 +47908,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -46217,8 +47939,9 @@
 # ---
 # name: test_climate_floorheatingairflow[climate.laurens_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -46265,18 +47988,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.laurens_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Laurens Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -46343,8 +48067,9 @@
 # ---
 # name: test_climate_floorheatingairflow[climate.woonkamer_airco_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -46387,18 +48112,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.woonkamer_airco_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Woonkamer airco Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -46460,8 +48186,9 @@
 # ---
 # name: test_climate_floorheatingairflow[select.laurens_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -46486,6 +48213,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -46522,8 +48250,9 @@
 # ---
 # name: test_climate_floorheatingairflow[select.woonkamer_airco_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -46548,6 +48277,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -46584,8 +48314,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46605,6 +48336,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46641,8 +48373,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46662,6 +48395,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46698,8 +48432,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46719,6 +48454,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46755,8 +48491,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46776,6 +48513,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46812,8 +48550,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -46831,6 +48570,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -46861,8 +48601,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46882,6 +48623,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46918,8 +48660,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46939,6 +48682,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -46970,13 +48714,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.7',
+    'state': '3.6',
   })
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -46996,6 +48741,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47032,8 +48778,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47053,6 +48800,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47089,8 +48837,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -47110,6 +48859,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -47146,8 +48896,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -47167,6 +48918,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -47203,8 +48955,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47222,6 +48975,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47252,8 +49006,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -47273,6 +49028,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47304,8 +49060,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47323,6 +49080,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47353,8 +49111,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47372,6 +49131,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47402,8 +49162,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47421,6 +49182,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47451,8 +49213,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47470,6 +49233,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47500,8 +49264,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -47521,6 +49286,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -47554,8 +49320,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47573,6 +49340,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47603,8 +49371,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.laurens_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47622,6 +49391,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47652,8 +49422,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47673,6 +49444,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47709,8 +49481,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47730,6 +49503,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47766,8 +49540,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47787,6 +49562,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47823,8 +49599,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47844,6 +49621,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47880,8 +49658,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -47899,6 +49678,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -47929,8 +49709,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -47950,6 +49731,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -47986,8 +49768,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -48007,6 +49790,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -48043,8 +49827,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -48064,6 +49849,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -48100,8 +49886,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -48121,6 +49908,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -48157,8 +49945,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -48178,6 +49967,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -48214,8 +50004,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_room_humidity-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -48235,6 +50026,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room humidity',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
@@ -48268,8 +50060,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -48289,6 +50082,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -48325,8 +50119,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48344,6 +50139,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48374,8 +50170,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -48395,6 +50192,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48426,8 +50224,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_region_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48445,6 +50244,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Region code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48475,8 +50275,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48494,6 +50295,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48524,8 +50326,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_time_zone-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48543,6 +50346,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Time zone',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48573,8 +50377,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_wifi_connection_ssid-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48592,6 +50397,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection SSID',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48622,8 +50428,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_gateway_wifi_connection_strength-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -48643,6 +50450,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'WiFi connection strength',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
@@ -48676,8 +50484,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_indoorunit_dry_keep_setting-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48695,6 +50504,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Dry keep setting',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48725,8 +50535,9 @@
 # ---
 # name: test_climate_floorheatingairflow[sensor.woonkamer_airco_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48744,6 +50555,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48774,8 +50586,9 @@
 # ---
 # name: test_climate_floorheatingairflow[switch.laurens_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48793,6 +50606,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48823,8 +50637,9 @@
 # ---
 # name: test_climate_floorheatingairflow[switch.laurens_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48842,6 +50657,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48872,8 +50688,9 @@
 # ---
 # name: test_climate_floorheatingairflow[switch.woonkamer_airco_climatecontrol_econo_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48891,6 +50708,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Econo mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48921,8 +50739,9 @@
 # ---
 # name: test_climate_floorheatingairflow[switch.woonkamer_airco_climatecontrol_streamer_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48940,6 +50759,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Streamer mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -48970,8 +50790,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -48989,6 +50810,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -49019,8 +50841,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49038,6 +50861,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49069,8 +50893,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49088,6 +50913,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49119,8 +50945,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49138,6 +50965,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49169,8 +50997,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49188,6 +51017,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -49218,8 +51048,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49237,6 +51068,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49268,8 +51100,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49287,6 +51120,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49318,8 +51152,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49337,6 +51172,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49368,8 +51204,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49387,6 +51224,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49418,8 +51256,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49437,6 +51276,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -49467,8 +51307,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49486,6 +51327,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49517,8 +51359,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49536,6 +51379,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49567,8 +51411,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49586,6 +51431,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49617,8 +51463,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49636,6 +51483,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -49666,8 +51514,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49685,6 +51534,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49716,8 +51566,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49735,6 +51586,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49766,8 +51618,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49785,6 +51638,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49816,8 +51670,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_2_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49835,6 +51690,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49866,8 +51722,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49885,6 +51742,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -49915,8 +51773,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49934,6 +51793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -49965,8 +51825,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -49984,6 +51845,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50015,8 +51877,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50034,6 +51897,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50065,8 +51929,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50084,6 +51949,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -50114,8 +51980,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50133,6 +52000,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50164,8 +52032,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50183,6 +52052,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50214,8 +52084,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50233,6 +52104,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50264,8 +52136,9 @@
 # ---
 # name: test_dry2[binary_sensor.bedroom_3_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50283,6 +52156,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50314,8 +52188,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50333,6 +52208,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -50363,8 +52239,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50382,6 +52259,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50413,8 +52291,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50432,6 +52311,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50463,8 +52343,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50482,6 +52363,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50513,8 +52395,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50532,6 +52415,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -50562,8 +52446,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50581,6 +52466,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50612,8 +52498,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50631,6 +52518,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50662,8 +52550,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50681,6 +52570,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50712,8 +52602,9 @@
 # ---
 # name: test_dry2[binary_sensor.kitchen_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50731,6 +52622,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50762,8 +52654,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50781,6 +52674,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -50811,8 +52705,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50830,6 +52725,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50861,8 +52757,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50880,6 +52777,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50911,8 +52809,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50930,6 +52829,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -50961,8 +52861,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -50980,6 +52881,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -51010,8 +52912,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51029,6 +52932,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51060,8 +52964,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51079,6 +52984,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51110,8 +53016,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51129,6 +53036,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51160,8 +53068,9 @@
 # ---
 # name: test_dry2[binary_sensor.lounge_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51179,6 +53088,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51210,8 +53120,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51229,6 +53140,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -51259,8 +53171,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51278,6 +53191,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51309,8 +53223,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51328,6 +53243,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51359,8 +53275,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51378,6 +53295,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51409,8 +53327,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51428,6 +53347,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -51458,8 +53378,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51477,6 +53398,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51508,8 +53430,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51527,6 +53450,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51558,8 +53482,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51577,6 +53502,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51608,8 +53534,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bathroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51627,6 +53554,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51658,8 +53586,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51677,6 +53606,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -51707,8 +53637,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51726,6 +53657,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51757,8 +53689,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51776,6 +53709,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51807,8 +53741,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51826,6 +53761,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51857,8 +53793,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51876,6 +53813,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -51906,8 +53844,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51925,6 +53864,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -51956,8 +53896,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -51975,6 +53916,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -52006,8 +53948,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52025,6 +53968,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -52056,8 +54000,9 @@
 # ---
 # name: test_dry2[binary_sensor.master_bedroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52075,6 +54020,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -52106,8 +54052,9 @@
 # ---
 # name: test_dry2[button.bedroom_1_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52125,6 +54072,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52155,8 +54103,9 @@
 # ---
 # name: test_dry2[button.bedroom_2_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52174,6 +54123,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52204,8 +54154,9 @@
 # ---
 # name: test_dry2[button.bedroom_3_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52223,6 +54174,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52253,8 +54205,9 @@
 # ---
 # name: test_dry2[button.kitchen_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52272,6 +54225,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52302,8 +54256,9 @@
 # ---
 # name: test_dry2[button.lounge_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52321,6 +54276,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52351,8 +54307,9 @@
 # ---
 # name: test_dry2[button.master_bathroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52370,6 +54327,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52400,8 +54358,9 @@
 # ---
 # name: test_dry2[button.master_bedroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -52419,6 +54378,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -52449,8 +54409,9 @@
 # ---
 # name: test_dry2[climate.bedroom_1_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52474,18 +54435,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_1_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 1 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52525,8 +54487,9 @@
 # ---
 # name: test_dry2[climate.bedroom_2_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52550,18 +54513,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_2_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 2 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52601,8 +54565,9 @@
 # ---
 # name: test_dry2[climate.bedroom_3_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52631,18 +54596,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_3_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 3 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52688,8 +54654,9 @@
 # ---
 # name: test_dry2[climate.kitchen_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52713,18 +54680,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.kitchen_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Kitchen Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52764,8 +54732,9 @@
 # ---
 # name: test_dry2[climate.lounge_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52789,18 +54758,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.lounge_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Lounge Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52840,8 +54810,9 @@
 # ---
 # name: test_dry2[climate.master_bathroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52865,18 +54836,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bathroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bathroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52916,8 +54888,9 @@
 # ---
 # name: test_dry2[climate.master_bedroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -52941,18 +54914,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bedroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bedroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -52992,8 +54966,9 @@
 # ---
 # name: test_dry2[select.bedroom_1_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53018,6 +54993,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53054,8 +55030,9 @@
 # ---
 # name: test_dry2[select.bedroom_2_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53080,6 +55057,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53116,8 +55094,9 @@
 # ---
 # name: test_dry2[select.bedroom_3_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53140,6 +55119,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53174,8 +55154,9 @@
 # ---
 # name: test_dry2[select.kitchen_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53200,6 +55181,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53236,8 +55218,9 @@
 # ---
 # name: test_dry2[select.lounge_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53262,6 +55245,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53298,8 +55282,9 @@
 # ---
 # name: test_dry2[select.master_bathroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53324,6 +55309,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53360,8 +55346,9 @@
 # ---
 # name: test_dry2[select.master_bedroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -53386,6 +55373,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53422,8 +55410,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53441,6 +55430,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53471,8 +55461,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -53492,6 +55483,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -53528,8 +55520,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53547,6 +55540,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53577,8 +55571,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53596,6 +55591,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53626,8 +55622,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -53647,6 +55644,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53678,8 +55676,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_1_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53697,6 +55696,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53727,8 +55727,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53746,6 +55747,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53776,8 +55778,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -53797,6 +55800,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -53833,8 +55837,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53852,6 +55857,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53882,8 +55888,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -53901,6 +55908,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53931,8 +55939,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -53952,6 +55961,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -53983,8 +55993,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_2_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54002,6 +56013,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54032,8 +56044,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54051,6 +56064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54081,8 +56095,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54102,6 +56117,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -54138,8 +56154,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54157,6 +56174,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54187,8 +56205,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54206,6 +56225,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54236,8 +56256,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54257,6 +56278,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54288,8 +56310,9 @@
 # ---
 # name: test_dry2[sensor.bedroom_3_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54307,6 +56330,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54337,8 +56361,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54356,6 +56381,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54386,8 +56412,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54407,6 +56434,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -54443,8 +56471,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54462,6 +56491,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54492,8 +56522,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54511,6 +56542,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54541,8 +56573,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54562,6 +56595,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54593,8 +56627,9 @@
 # ---
 # name: test_dry2[sensor.kitchen_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54612,6 +56647,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54642,8 +56678,9 @@
 # ---
 # name: test_dry2[sensor.lounge_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54661,6 +56698,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54691,8 +56729,9 @@
 # ---
 # name: test_dry2[sensor.lounge_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54712,6 +56751,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -54748,8 +56788,9 @@
 # ---
 # name: test_dry2[sensor.lounge_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54767,6 +56808,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54797,8 +56839,9 @@
 # ---
 # name: test_dry2[sensor.lounge_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54816,6 +56859,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54846,8 +56890,9 @@
 # ---
 # name: test_dry2[sensor.lounge_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -54867,6 +56912,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54898,8 +56944,9 @@
 # ---
 # name: test_dry2[sensor.lounge_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54917,6 +56964,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54947,8 +56995,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -54966,6 +57015,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -54996,8 +57046,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -55017,6 +57068,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -55053,8 +57105,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55072,6 +57125,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55102,8 +57156,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55121,6 +57176,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55151,8 +57207,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -55172,6 +57229,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55203,8 +57261,9 @@
 # ---
 # name: test_dry2[sensor.master_bathroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55222,6 +57281,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55252,8 +57312,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55271,6 +57332,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55301,8 +57363,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -55322,6 +57385,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -55358,8 +57422,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55377,6 +57442,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55407,8 +57473,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55426,6 +57493,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55456,8 +57524,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -55477,6 +57546,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55508,8 +57578,9 @@
 # ---
 # name: test_dry2[sensor.master_bedroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55527,6 +57598,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55557,8 +57629,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55576,6 +57649,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55606,8 +57680,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55625,6 +57700,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55656,8 +57732,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55675,6 +57752,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55706,8 +57784,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55725,6 +57804,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55756,8 +57836,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55775,6 +57856,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -55805,8 +57887,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55824,6 +57907,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55855,8 +57939,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55874,6 +57959,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55905,8 +57991,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55924,6 +58011,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -55955,8 +58043,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_1_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -55974,6 +58063,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56005,8 +58095,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56024,6 +58115,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -56054,8 +58146,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56073,6 +58166,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56104,8 +58198,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56123,6 +58218,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56154,8 +58250,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56173,6 +58270,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56204,8 +58302,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56223,6 +58322,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -56253,8 +58353,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56272,6 +58373,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56303,8 +58405,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56322,6 +58425,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56353,8 +58457,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56372,6 +58477,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56403,8 +58509,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_2_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56422,6 +58529,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56453,8 +58561,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56472,6 +58581,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -56502,8 +58612,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56521,6 +58632,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56552,8 +58664,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56571,6 +58684,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56602,8 +58716,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56621,6 +58736,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56652,8 +58768,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56671,6 +58788,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -56701,8 +58819,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56720,6 +58839,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56751,8 +58871,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56770,6 +58891,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56801,8 +58923,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56820,6 +58943,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56851,8 +58975,9 @@
 # ---
 # name: test_dry[binary_sensor.bedroom_3_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56870,6 +58995,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -56901,8 +59027,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56920,6 +59047,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -56950,8 +59078,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -56969,6 +59098,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57000,8 +59130,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57019,6 +59150,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57050,8 +59182,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57069,6 +59202,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57100,8 +59234,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57119,6 +59254,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -57149,8 +59285,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57168,6 +59305,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57199,8 +59337,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57218,6 +59357,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57249,8 +59389,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57268,6 +59409,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57299,8 +59441,9 @@
 # ---
 # name: test_dry[binary_sensor.kitchen_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57318,6 +59461,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57349,8 +59493,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57368,6 +59513,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -57398,8 +59544,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57417,6 +59564,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57448,8 +59596,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57467,6 +59616,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57498,8 +59648,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57517,6 +59668,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57548,8 +59700,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57567,6 +59720,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -57597,8 +59751,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57616,6 +59771,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57647,8 +59803,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57666,6 +59823,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57697,8 +59855,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57716,6 +59875,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57747,8 +59907,9 @@
 # ---
 # name: test_dry[binary_sensor.lounge_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57766,6 +59927,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57797,8 +59959,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57816,6 +59979,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -57846,8 +60010,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57865,6 +60030,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57896,8 +60062,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57915,6 +60082,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57946,8 +60114,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -57965,6 +60134,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -57996,8 +60166,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58015,6 +60186,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58045,8 +60217,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58064,6 +60237,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58095,8 +60269,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58114,6 +60289,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58145,8 +60321,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58164,6 +60341,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58195,8 +60373,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bathroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58214,6 +60393,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58245,8 +60425,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58264,6 +60445,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58294,8 +60476,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58313,6 +60496,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58344,8 +60528,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58363,6 +60548,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58394,8 +60580,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58413,6 +60600,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58444,8 +60632,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58463,6 +60652,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58493,8 +60683,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58512,6 +60703,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58543,8 +60735,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58562,6 +60755,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58593,8 +60787,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58612,6 +60807,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58643,8 +60839,9 @@
 # ---
 # name: test_dry[binary_sensor.master_bedroom_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58662,6 +60859,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -58693,8 +60891,9 @@
 # ---
 # name: test_dry[button.bedroom_1_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58712,6 +60911,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58742,8 +60942,9 @@
 # ---
 # name: test_dry[button.bedroom_2_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58761,6 +60962,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58791,8 +60993,9 @@
 # ---
 # name: test_dry[button.bedroom_3_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58810,6 +61013,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58840,8 +61044,9 @@
 # ---
 # name: test_dry[button.kitchen_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58859,6 +61064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58889,8 +61095,9 @@
 # ---
 # name: test_dry[button.lounge_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58908,6 +61115,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58938,8 +61146,9 @@
 # ---
 # name: test_dry[button.master_bathroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -58957,6 +61166,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -58987,8 +61197,9 @@
 # ---
 # name: test_dry[button.master_bedroom_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -59006,6 +61217,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59036,8 +61248,9 @@
 # ---
 # name: test_dry[climate.bedroom_1_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59061,18 +61274,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_1_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 1 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59112,8 +61326,9 @@
 # ---
 # name: test_dry[climate.bedroom_2_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59137,18 +61352,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_2_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 2 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59188,8 +61404,9 @@
 # ---
 # name: test_dry[climate.bedroom_3_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59218,18 +61435,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.bedroom_3_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bedroom 3 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59275,8 +61493,9 @@
 # ---
 # name: test_dry[climate.kitchen_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59300,18 +61519,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.kitchen_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Kitchen Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59351,8 +61571,9 @@
 # ---
 # name: test_dry[climate.lounge_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59376,18 +61597,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.lounge_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Lounge Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59427,8 +61649,9 @@
 # ---
 # name: test_dry[climate.master_bathroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59452,18 +61675,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bathroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bathroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59503,8 +61727,9 @@
 # ---
 # name: test_dry[climate.master_bedroom_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -59528,18 +61753,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_bedroom_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Bedroom Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -59579,8 +61805,9 @@
 # ---
 # name: test_dry[select.bedroom_1_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59605,6 +61832,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59641,8 +61869,9 @@
 # ---
 # name: test_dry[select.bedroom_2_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59667,6 +61896,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59703,8 +61933,9 @@
 # ---
 # name: test_dry[select.bedroom_3_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59727,6 +61958,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59761,8 +61993,9 @@
 # ---
 # name: test_dry[select.kitchen_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59787,6 +62020,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59823,8 +62057,9 @@
 # ---
 # name: test_dry[select.lounge_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59849,6 +62084,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59885,8 +62121,9 @@
 # ---
 # name: test_dry[select.master_bathroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59911,6 +62148,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -59947,8 +62185,9 @@
 # ---
 # name: test_dry[select.master_bedroom_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -59973,6 +62212,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60009,8 +62249,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60028,6 +62269,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60058,8 +62300,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60079,6 +62322,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -60115,8 +62359,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60134,6 +62379,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60164,8 +62410,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60183,6 +62430,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60213,8 +62461,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60234,6 +62483,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60265,8 +62515,9 @@
 # ---
 # name: test_dry[sensor.bedroom_1_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60284,6 +62535,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60314,8 +62566,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60333,6 +62586,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60363,8 +62617,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60384,6 +62639,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -60420,8 +62676,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60439,6 +62696,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60469,8 +62727,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60488,6 +62747,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60518,8 +62778,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60539,6 +62800,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60570,8 +62832,9 @@
 # ---
 # name: test_dry[sensor.bedroom_2_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60589,6 +62852,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60619,8 +62883,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60638,6 +62903,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60668,8 +62934,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60689,6 +62956,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -60725,8 +62993,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60744,6 +63013,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60774,8 +63044,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60793,6 +63064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60823,8 +63095,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60844,6 +63117,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60875,8 +63149,9 @@
 # ---
 # name: test_dry[sensor.bedroom_3_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60894,6 +63169,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60924,8 +63200,9 @@
 # ---
 # name: test_dry[sensor.kitchen_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -60943,6 +63220,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -60973,8 +63251,9 @@
 # ---
 # name: test_dry[sensor.kitchen_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -60994,6 +63273,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -61030,8 +63310,9 @@
 # ---
 # name: test_dry[sensor.kitchen_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61049,6 +63330,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61079,8 +63361,9 @@
 # ---
 # name: test_dry[sensor.kitchen_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61098,6 +63381,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61128,8 +63412,9 @@
 # ---
 # name: test_dry[sensor.kitchen_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61149,6 +63434,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61180,8 +63466,9 @@
 # ---
 # name: test_dry[sensor.kitchen_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61199,6 +63486,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61229,8 +63517,9 @@
 # ---
 # name: test_dry[sensor.lounge_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61248,6 +63537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61278,8 +63568,9 @@
 # ---
 # name: test_dry[sensor.lounge_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61299,6 +63590,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -61335,8 +63627,9 @@
 # ---
 # name: test_dry[sensor.lounge_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61354,6 +63647,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61384,8 +63678,9 @@
 # ---
 # name: test_dry[sensor.lounge_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61403,6 +63698,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61433,8 +63729,9 @@
 # ---
 # name: test_dry[sensor.lounge_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61454,6 +63751,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61485,8 +63783,9 @@
 # ---
 # name: test_dry[sensor.lounge_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61504,6 +63803,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61534,8 +63834,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61553,6 +63854,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61583,8 +63885,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61604,6 +63907,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -61640,8 +63944,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61659,6 +63964,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61689,8 +63995,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61708,6 +64015,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61738,8 +64046,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61759,6 +64068,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61790,8 +64100,9 @@
 # ---
 # name: test_dry[sensor.master_bathroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61809,6 +64120,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61839,8 +64151,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61858,6 +64171,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61888,8 +64202,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -61909,6 +64224,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -61945,8 +64261,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -61964,6 +64281,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -61994,8 +64312,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62013,6 +64332,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62043,8 +64363,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -62064,6 +64385,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62095,8 +64417,9 @@
 # ---
 # name: test_dry[sensor.master_bedroom_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62114,6 +64437,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62144,8 +64468,9 @@
 # ---
 # name: test_fanmode[binary_sensor.sala_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62163,6 +64488,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62193,8 +64519,9 @@
 # ---
 # name: test_fanmode[binary_sensor.sala_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62212,6 +64539,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -62243,8 +64571,9 @@
 # ---
 # name: test_fanmode[binary_sensor.sala_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62262,6 +64591,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62292,8 +64622,9 @@
 # ---
 # name: test_fanmode[binary_sensor.sala_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62311,6 +64642,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62341,8 +64673,9 @@
 # ---
 # name: test_fanmode[button.sala_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62360,6 +64693,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62390,8 +64724,9 @@
 # ---
 # name: test_fanmode[climate.sala_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -62436,18 +64771,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.sala_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Sala Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -62512,8 +64848,9 @@
 # ---
 # name: test_fanmode[select.sala_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -62538,6 +64875,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62574,8 +64912,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62595,6 +64934,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62631,8 +64971,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62652,6 +64993,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62688,8 +65030,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62709,6 +65052,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62745,8 +65089,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62766,6 +65111,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62802,8 +65148,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -62821,6 +65168,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -62851,8 +65199,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62872,6 +65221,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62908,8 +65258,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62929,6 +65280,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -62960,13 +65312,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.9',
+    'state': '0.3',
   })
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -62986,6 +65339,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -63022,8 +65376,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -63043,6 +65398,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -63079,8 +65435,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -63100,6 +65457,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -63136,8 +65494,9 @@
 # ---
 # name: test_fanmode[sensor.sala_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -63157,6 +65516,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -63193,8 +65553,9 @@
 # ---
 # name: test_fanmode[sensor.sala_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -63212,6 +65573,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63242,8 +65604,9 @@
 # ---
 # name: test_fanmode[sensor.sala_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -63263,6 +65626,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63294,8 +65658,9 @@
 # ---
 # name: test_gas[binary_sensor.my_living_room_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -63313,6 +65678,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63343,8 +65709,9 @@
 # ---
 # name: test_gas[binary_sensor.my_living_room_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -63362,6 +65729,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63392,8 +65760,9 @@
 # ---
 # name: test_gas[button.my_living_room_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -63411,6 +65780,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63441,8 +65811,9 @@
 # ---
 # name: test_gas[climate.my_living_room_calculated_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -63467,18 +65838,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.my_living_room_calculated_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Calculated Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'My Living Room Calculated Leaving Water Temperature',
+    'original_name': 'Calculated Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -63519,8 +65891,9 @@
 # ---
 # name: test_gas[climate.my_living_room_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -63545,18 +65918,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.my_living_room_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'My Living Room Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -63597,8 +65971,9 @@
 # ---
 # name: test_gas[climate.my_living_room_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -63623,18 +65998,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.my_living_room_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'My Living Room Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -63676,8 +66052,9 @@
 # ---
 # name: test_gas[select.my_living_room_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -63701,6 +66078,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63736,8 +66114,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -63755,6 +66134,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -63785,8 +66165,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -63806,6 +66187,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -63842,8 +66224,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_daily_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -63863,6 +66246,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -63899,8 +66283,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -63920,6 +66305,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -63956,8 +66342,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_monthly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -63977,6 +66364,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64013,8 +66401,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64034,6 +66423,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64070,8 +66460,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_weekly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64091,6 +66482,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64127,8 +66519,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64148,6 +66541,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64184,8 +66578,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_cooling_yearly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64205,6 +66600,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64241,8 +66637,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -64260,6 +66657,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -64290,8 +66688,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64311,6 +66710,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64347,8 +66747,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_daily_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64368,6 +66769,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64404,8 +66806,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64425,6 +66828,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64461,8 +66865,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_monthly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64482,6 +66887,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64518,8 +66924,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64539,6 +66946,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64575,8 +66983,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_weekly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64596,6 +67005,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64632,8 +67042,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64653,6 +67064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64689,8 +67101,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_heating_yearly_gas_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -64710,6 +67123,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly gas consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -64746,8 +67160,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -64767,6 +67182,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -64803,8 +67219,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -64824,6 +67241,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -64860,8 +67278,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -64881,6 +67300,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -64917,8 +67337,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -64936,6 +67357,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -64966,8 +67388,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -64987,6 +67410,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -65008,7 +67432,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'My Living Room DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'My Living Room Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -65023,8 +67447,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65042,6 +67467,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65072,8 +67498,9 @@
 # ---
 # name: test_gas[sensor.my_living_room_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -65093,6 +67520,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65124,8 +67552,9 @@
 # ---
 # name: test_gas[water_heater.my_living_room-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': None,
@@ -65150,6 +67579,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'My Living Room',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65191,8 +67621,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65210,6 +67641,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65240,8 +67672,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65259,6 +67692,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -65290,8 +67724,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65309,6 +67744,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -65340,8 +67776,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_domestichotwaterflowthrough_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65359,6 +67796,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65389,8 +67827,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_domestichotwaterflowthrough_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65408,6 +67847,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -65439,8 +67879,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_domestichotwaterflowthrough_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65458,6 +67899,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -65489,8 +67931,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65508,6 +67951,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65538,8 +67982,9 @@
 # ---
 # name: test_holidaymode[binary_sensor.ndj_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65557,6 +68002,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -65588,8 +68034,9 @@
 # ---
 # name: test_holidaymode[button.ndj_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65607,6 +68054,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65637,8 +68085,9 @@
 # ---
 # name: test_holidaymode[climate.ndj_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -65661,18 +68110,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.ndj_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'NDJ Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -65711,8 +68161,9 @@
 # ---
 # name: test_holidaymode[select.ndj_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -65735,6 +68186,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65769,8 +68221,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65788,6 +68241,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65818,8 +68272,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65837,6 +68292,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65867,8 +68323,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_climatecontrol_on_off_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65886,6 +68343,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'On/Off mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -65916,8 +68374,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -65937,6 +68396,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -65973,8 +68433,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -65992,6 +68453,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66022,8 +68484,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_on_off_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66041,6 +68504,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'On/Off mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66071,8 +68535,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66090,6 +68555,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66120,8 +68586,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66139,6 +68606,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66169,8 +68637,9 @@
 # ---
 # name: test_holidaymode[sensor.ndj_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -66190,6 +68659,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66221,8 +68691,9 @@
 # ---
 # name: test_holidaymode[water_heater.ndj-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -66247,6 +68718,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'NDJ',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66265,7 +68737,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'NDJ',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough NDJ',
       'max_temp': 60.0,
       'min_temp': 35.0,
       'operation_list': list([
@@ -66289,8 +68761,9 @@
 # ---
 # name: test_homehub[button.homehub_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66308,6 +68781,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66338,8 +68812,9 @@
 # ---
 # name: test_homehub[sensor.homehub_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -66359,6 +68834,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66390,8 +68866,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66409,6 +68886,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66439,8 +68917,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66458,6 +68937,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66489,8 +68969,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66508,6 +68989,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66539,8 +69021,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66558,6 +69041,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66589,8 +69073,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66608,6 +69093,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66638,8 +69124,9 @@
 # ---
 # name: test_mc80z[binary_sensor.air_purifier_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66657,6 +69144,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66688,8 +69176,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66707,6 +69196,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66737,8 +69227,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66756,6 +69247,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66787,8 +69279,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66806,6 +69299,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66837,8 +69331,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66856,6 +69351,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66886,8 +69382,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66905,6 +69402,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -66936,8 +69434,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -66955,6 +69454,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -66985,8 +69485,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67004,6 +69505,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -67035,8 +69537,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67054,6 +69557,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -67085,8 +69589,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67104,6 +69609,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67134,8 +69640,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67153,6 +69660,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -67184,8 +69692,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67203,6 +69712,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67233,8 +69743,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67252,6 +69763,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67282,8 +69794,9 @@
 # ---
 # name: test_mc80z[binary_sensor.vloerverwarming_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67301,6 +69814,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -67332,8 +69846,9 @@
 # ---
 # name: test_mc80z[button.air_purifier_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67351,6 +69866,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67381,8 +69897,9 @@
 # ---
 # name: test_mc80z[button.vloerverwarming_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67400,6 +69917,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67430,8 +69948,9 @@
 # ---
 # name: test_mc80z[climate.vloerverwarming_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -67456,18 +69975,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.vloerverwarming_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Vloerverwarming Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -67509,8 +70029,9 @@
 # ---
 # name: test_mc80z[select.air_purifier_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -67535,6 +70056,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67571,8 +70093,9 @@
 # ---
 # name: test_mc80z[select.vloerverwarming_domestichotwatertank_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -67594,6 +70117,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67627,8 +70151,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_air_purification_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67646,6 +70171,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Air purification mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67676,8 +70202,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -67695,6 +70222,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -67725,8 +70253,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm10_concentration-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -67746,6 +70275,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'PM10 concentration',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.PM10: 'pm10'>,
@@ -67779,8 +70309,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm1_concentration-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -67800,6 +70331,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'PM1 concentration',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.PM1: 'pm1'>,
@@ -67833,8 +70365,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm2_5_concentration-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -67854,6 +70387,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'PM2.5 concentration',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.PM25: 'pm25'>,
@@ -67887,8 +70421,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_room_humidity-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -67908,6 +70443,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room humidity',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
@@ -67941,8 +70477,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -67962,6 +70499,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -67998,8 +70536,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68017,6 +70556,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68047,8 +70587,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68066,6 +70607,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68096,8 +70638,9 @@
 # ---
 # name: test_mc80z[sensor.air_purifier_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -68117,6 +70660,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68148,8 +70692,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68167,6 +70712,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68197,8 +70743,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68218,6 +70765,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68254,8 +70802,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68275,6 +70824,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68311,8 +70861,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68332,6 +70883,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68368,8 +70920,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68389,6 +70942,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68425,8 +70979,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68444,6 +70999,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68474,8 +71030,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68495,6 +71052,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68531,8 +71089,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68552,6 +71111,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68583,13 +71143,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '325',
+    'state': '0',
   })
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68609,6 +71170,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68645,8 +71207,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68666,6 +71229,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -68702,8 +71266,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -68723,6 +71288,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -68759,8 +71325,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -68780,6 +71347,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -68816,8 +71384,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68835,6 +71404,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68865,8 +71435,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68884,6 +71455,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68914,8 +71486,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -68933,6 +71506,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -68963,8 +71537,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -68984,6 +71559,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -69020,8 +71596,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -69041,6 +71618,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -69072,13 +71650,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '49',
+    'state': '0',
   })
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -69098,6 +71677,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -69134,8 +71714,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -69155,6 +71736,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -69191,8 +71773,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69210,6 +71793,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69240,8 +71824,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -69261,6 +71846,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -69297,8 +71883,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69316,6 +71903,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69346,8 +71934,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69365,6 +71954,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69395,8 +71985,9 @@
 # ---
 # name: test_mc80z[sensor.vloerverwarming_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -69416,6 +72007,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69447,8 +72039,9 @@
 # ---
 # name: test_mc80z[water_heater.vloerverwarming-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 60.0,
@@ -69474,6 +72067,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Vloerverwarming',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69492,7 +72086,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 41.0,
-      'friendly_name': 'Vloerverwarming',
+      'friendly_name': 'Vloerverwarming DomesticHotWaterTank Vloerverwarming',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -69517,8 +72111,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69536,6 +72131,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69566,8 +72162,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69585,6 +72182,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -69616,8 +72214,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69635,6 +72234,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -69666,8 +72266,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69685,6 +72286,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69715,8 +72317,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69734,6 +72337,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69764,8 +72368,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69783,6 +72388,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -69814,8 +72420,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69833,6 +72440,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69863,8 +72471,9 @@
 # ---
 # name: test_minimal_data[binary_sensor.altherma_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69882,6 +72491,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69912,8 +72522,9 @@
 # ---
 # name: test_minimal_data[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -69931,6 +72542,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -69961,8 +72573,9 @@
 # ---
 # name: test_minimal_data[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -69982,18 +72595,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -70028,8 +72642,9 @@
 # ---
 # name: test_minimal_data[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -70050,18 +72665,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -70098,8 +72714,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -70117,6 +72734,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -70147,8 +72765,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70168,6 +72787,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70204,8 +72824,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70225,6 +72846,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70256,13 +72878,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '8',
   })
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70282,6 +72905,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70318,8 +72942,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70339,6 +72964,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70375,8 +73001,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70396,6 +73023,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70432,8 +73060,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70453,6 +73082,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70484,13 +73114,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '755',
+    'state': '112',
   })
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70510,6 +73141,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70546,8 +73178,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70567,6 +73200,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70603,8 +73237,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -70624,6 +73259,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -70660,8 +73296,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -70681,6 +73318,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -70717,8 +73355,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -70738,6 +73377,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -70774,8 +73414,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -70793,6 +73434,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -70823,8 +73465,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -70842,6 +73485,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -70872,8 +73516,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70893,6 +73538,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70929,8 +73575,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -70950,6 +73597,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -70981,13 +73629,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '143',
+    'state': '107',
   })
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -71007,6 +73656,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -71043,8 +73693,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -71064,6 +73715,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -71100,8 +73752,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71119,6 +73772,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71149,8 +73803,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -71170,6 +73825,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -71206,8 +73862,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71225,6 +73882,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71255,8 +73913,9 @@
 # ---
 # name: test_minimal_data[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -71276,6 +73935,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71307,8 +73967,9 @@
 # ---
 # name: test_minimal_data[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': None,
@@ -71333,6 +73994,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71351,7 +74013,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 53.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': None,
       'min_temp': None,
       'operation_list': list([
@@ -71374,8 +74036,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71393,6 +74056,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71423,8 +74087,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_climatecontrol_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71442,6 +74107,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71473,8 +74139,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71492,6 +74159,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71523,8 +74191,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71542,6 +74211,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71573,8 +74243,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71592,6 +74263,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71622,8 +74294,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71641,6 +74314,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71671,8 +74345,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_gateway_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71690,6 +74365,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71721,8 +74397,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_outdoorunit_is_in_caution_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71740,6 +74417,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in caution state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71771,8 +74449,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_outdoorunit_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71790,6 +74469,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71821,8 +74501,9 @@
 # ---
 # name: test_offlinedevice[binary_sensor.studio_outdoorunit_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71840,6 +74521,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -71871,8 +74553,9 @@
 # ---
 # name: test_offlinedevice[button.studio_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -71890,6 +74573,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -71920,8 +74604,9 @@
 # ---
 # name: test_offlinedevice[climate.studio_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -71963,18 +74648,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.studio_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Studio Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -72030,8 +74716,9 @@
 # ---
 # name: test_offlinedevice[select.studio_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -72053,6 +74740,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72086,8 +74774,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72107,6 +74796,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72143,8 +74833,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72164,6 +74855,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72200,8 +74892,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72221,6 +74914,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72257,8 +74951,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72278,6 +74973,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72314,8 +75010,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72333,6 +75030,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72363,8 +75061,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72384,6 +75083,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72420,8 +75120,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72441,6 +75142,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72477,8 +75179,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72498,6 +75201,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72534,8 +75238,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -72555,6 +75260,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -72591,8 +75297,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_on_off_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72610,6 +75317,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'On/Off mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72640,8 +75348,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -72661,6 +75370,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -72697,8 +75407,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_powerful_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72716,6 +75427,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Powerful mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72746,8 +75458,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -72767,6 +75480,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -72803,8 +75517,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_gateway_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72822,6 +75537,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72852,8 +75568,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72871,6 +75588,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72901,8 +75619,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -72922,6 +75641,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -72953,8 +75673,9 @@
 # ---
 # name: test_offlinedevice[sensor.studio_outdoorunit_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -72972,6 +75693,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73002,8 +75724,9 @@
 # ---
 # name: test_schedule[binary_sensor.master_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73021,6 +75744,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73051,8 +75775,9 @@
 # ---
 # name: test_schedule[binary_sensor.master_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73070,6 +75795,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -73101,8 +75827,9 @@
 # ---
 # name: test_schedule[binary_sensor.master_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73120,6 +75847,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73150,8 +75878,9 @@
 # ---
 # name: test_schedule[binary_sensor.master_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73169,6 +75898,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73199,8 +75929,9 @@
 # ---
 # name: test_schedule[button.master_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73218,6 +75949,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73248,8 +75980,9 @@
 # ---
 # name: test_schedule[climate.master_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -73282,18 +76015,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.master_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Master Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -73344,8 +76078,9 @@
 # ---
 # name: test_schedule[select.master_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -73370,6 +76105,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73406,8 +76142,9 @@
 # ---
 # name: test_schedule[sensor.master_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73425,6 +76162,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73455,8 +76193,9 @@
 # ---
 # name: test_schedule[sensor.master_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -73476,6 +76215,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -73512,8 +76252,9 @@
 # ---
 # name: test_schedule[sensor.master_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73531,6 +76272,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73561,8 +76303,9 @@
 # ---
 # name: test_schedule[sensor.master_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -73582,6 +76325,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73613,8 +76357,9 @@
 # ---
 # name: test_ururu[binary_sensor.daikinap95800_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73632,6 +76377,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73662,8 +76408,9 @@
 # ---
 # name: test_ururu[binary_sensor.daikinap95800_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73681,6 +76428,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -73712,8 +76460,9 @@
 # ---
 # name: test_ururu[binary_sensor.daikinap95800_climatecontrol_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73731,6 +76480,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73761,8 +76511,9 @@
 # ---
 # name: test_ururu[binary_sensor.daikinap95800_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73780,6 +76531,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73810,8 +76562,9 @@
 # ---
 # name: test_ururu[button.daikinap95800_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -73829,6 +76582,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -73859,8 +76613,9 @@
 # ---
 # name: test_ururu[climate.daikinap95800_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
@@ -73903,18 +76658,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.daikinap95800_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'DaikinAP95800 Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -73977,8 +76733,9 @@
 # ---
 # name: test_ururu[select.daikinap95800_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -74003,6 +76760,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74039,8 +76797,9 @@
 # ---
 # name: test_ururu[sensor.daikinap95800_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74058,6 +76817,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74088,8 +76848,9 @@
 # ---
 # name: test_ururu[sensor.daikinap95800_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -74109,6 +76870,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -74145,8 +76907,9 @@
 # ---
 # name: test_ururu[sensor.daikinap95800_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -74166,6 +76929,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -74202,8 +76966,9 @@
 # ---
 # name: test_ururu[sensor.daikinap95800_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74221,6 +76986,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74251,8 +77017,9 @@
 # ---
 # name: test_ururu[sensor.daikinap95800_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -74272,6 +77039,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74303,8 +77071,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74322,6 +77091,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74352,8 +77122,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_climatecontrol_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74371,6 +77142,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74402,8 +77174,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_climatecontrol_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74421,6 +77194,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74452,8 +77226,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_climatecontrol_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74471,6 +77246,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74501,8 +77277,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_climatecontrol_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74520,6 +77297,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74551,8 +77329,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74570,6 +77349,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is holiday mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74600,8 +77380,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_emergency_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74619,6 +77400,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in emergency state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74650,8 +77432,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_error_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74669,6 +77452,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in error state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74700,8 +77484,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74719,6 +77504,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in installer state',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74749,8 +77535,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_warning_state-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74768,6 +77555,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is in warning state',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
@@ -74799,8 +77587,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74818,6 +77607,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is powerful mode active',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74848,8 +77638,9 @@
 # ---
 # name: test_water_heater[binary_sensor.altherma_gateway_is_firmware_update_supported-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74867,6 +77658,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Is firmware update supported',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74897,8 +77689,9 @@
 # ---
 # name: test_water_heater[button.altherma_refresh-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -74916,6 +77709,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Refresh',
     'options': dict({
     }),
     'original_device_class': None,
@@ -74946,8 +77740,9 @@
 # ---
 # name: test_water_heater[climate.altherma_leaving_water_offset-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -74972,18 +77767,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_offset',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Offset',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Offset',
+    'original_name': 'Leaving Water Offset',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -75025,8 +77821,9 @@
 # ---
 # name: test_water_heater[climate.altherma_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -75050,18 +77847,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_leaving_water_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving Water Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Leaving Water Temperature',
+    'original_name': 'Leaving Water Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -75101,8 +77899,9 @@
 # ---
 # name: test_water_heater[climate.altherma_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'hvac_modes': list([
@@ -75127,18 +77926,19 @@
     'domain': 'climate',
     'entity_category': None,
     'entity_id': 'climate.altherma_room_temperature',
-    'has_entity_name': False,
+    'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
     'id': <ANY>,
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room Temperature',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma Room Temperature',
+    'original_name': 'Room Temperature',
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -75180,8 +77980,9 @@
 # ---
 # name: test_water_heater[select.altherma_climatecontrol_schedule-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'options': list([
@@ -75206,6 +78007,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Schedule',
     'options': dict({
     }),
     'original_device_class': None,
@@ -75242,8 +78044,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_control_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -75261,6 +78064,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Control mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -75291,8 +78095,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_cooling_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75312,6 +78117,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75348,8 +78154,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_cooling_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75369,6 +78176,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75405,8 +78213,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_cooling_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75426,6 +78235,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75462,8 +78272,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_cooling_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75483,6 +78294,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Cooling yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75519,8 +78331,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -75538,6 +78351,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -75568,8 +78382,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75589,6 +78404,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75625,8 +78441,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75646,6 +78463,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75677,13 +78495,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '609',
+    'state': '0',
   })
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75703,6 +78522,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75739,8 +78559,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -75760,6 +78581,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -75796,8 +78618,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_leaving_water_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -75817,6 +78640,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Leaving water temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -75853,8 +78677,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_outdoor_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -75874,6 +78699,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Outdoor temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -75910,8 +78736,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_room_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -75931,6 +78758,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -75967,8 +78795,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_climatecontrol_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -75986,6 +78815,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76016,8 +78846,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_error_code-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -76035,6 +78866,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Error code',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76065,8 +78897,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heat_up_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -76084,6 +78917,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heat up mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76114,8 +78948,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heating_daily_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -76135,6 +78970,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating daily electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -76171,8 +79007,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heating_monthly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -76192,6 +79029,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating monthly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -76223,13 +79061,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '116',
+    'state': '0',
   })
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heating_weekly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -76249,6 +79088,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating weekly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -76285,8 +79125,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heating_yearly_electrical_consumption-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -76306,6 +79147,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Heating yearly electrical consumption',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -76342,8 +79184,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_setpoint_mode-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -76361,6 +79204,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Setpoint mode',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76391,8 +79235,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_domestichotwatertank_tank_temperature-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -76412,6 +79257,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Tank temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -76448,8 +79294,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_gateway_ip_address-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,
@@ -76467,6 +79314,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'IP address',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76497,8 +79345,9 @@
 # ---
 # name: test_water_heater[sensor.altherma_gateway_ratelimit_remaining_day-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -76518,6 +79367,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Ratelimit remaining day',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76549,8 +79399,9 @@
 # ---
 # name: test_water_heater[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': dict({
       'max_temp': 53.0,
@@ -76576,6 +79427,7 @@
     'labels': set({
     }),
     'name': None,
+    'object_id_base': 'Altherma',
     'options': dict({
     }),
     'original_device_class': None,
@@ -76594,7 +79446,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
       'max_temp': 53.0,
       'min_temp': 30.0,
       'operation_list': list([

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -297,7 +297,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -349,7 +349,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
+      'friendly_name': 'Altherma Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -401,7 +401,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -452,7 +452,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -504,7 +504,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
+      'friendly_name': 'Altherma Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -555,7 +555,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
+      'friendly_name': 'Altherma Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -789,7 +789,7 @@
 # name: test_altherma3m[select.altherma_domestichotwatertank_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Schedule',
+      'friendly_name': 'Altherma Schedule',
       'icon': 'mdi:calendar-clock',
       'options': list([
         'User defined',
@@ -1350,7 +1350,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
+      'friendly_name': 'Altherma Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1401,7 +1401,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
+      'friendly_name': 'Altherma Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1458,7 +1458,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1517,7 +1517,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1576,7 +1576,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1635,7 +1635,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1688,7 +1688,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1745,7 +1745,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -1912,7 +1912,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma',
       'max_temp': 50.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -37133,7 +37133,7 @@
 # name: test_climate[button.altherma_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Altherma Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -37184,7 +37184,7 @@
 # name: test_climate[button.johnny_maaike_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Johnny&Maaike Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -37235,7 +37235,7 @@
 # name: test_climate[button.linde_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Linde Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -37337,7 +37337,7 @@
 # name: test_climate[button.werkkamer_refresh-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Sanne Refresh',
+      'friendly_name': 'Werkkamer Refresh',
       'icon': 'mdi:refresh',
     }),
     'context': <ANY>,
@@ -37402,7 +37402,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27,
-      'friendly_name': 'Sanne Leaving Water Offset',
+      'friendly_name': 'Altherma Leaving Water Offset',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -37481,7 +37481,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 27,
-      'friendly_name': 'Sanne Leaving Water Temperature',
+      'friendly_name': 'Altherma Leaving Water Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -37562,7 +37562,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21,
-      'friendly_name': 'Sanne Room Temperature',
+      'friendly_name': 'Altherma Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -37675,7 +37675,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Sanne Room Temperature',
+      'friendly_name': 'Johnny&Maaike Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -37803,7 +37803,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Sanne Room Temperature',
+      'friendly_name': 'Linde Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -38059,7 +38059,7 @@
         '4',
         '5',
       ]),
-      'friendly_name': 'Sanne Room Temperature',
+      'friendly_name': 'Werkkamer Room Temperature',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.FAN_ONLY: 'fan_only'>,
@@ -77367,7 +77367,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77419,7 +77419,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
+      'friendly_name': 'Altherma Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77471,7 +77471,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77522,7 +77522,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77574,7 +77574,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
+      'friendly_name': 'Altherma Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77625,7 +77625,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
+      'friendly_name': 'Altherma Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -78884,7 +78884,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
+      'friendly_name': 'Altherma Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -78935,7 +78935,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
+      'friendly_name': 'Altherma Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -78992,7 +78992,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79051,7 +79051,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79110,7 +79110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79169,7 +79169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79222,7 +79222,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -79279,7 +79279,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -79446,7 +79446,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma',
       'max_temp': 53.0,
       'min_temp': 30.0,
       'operation_list': list([

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -297,7 +297,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -349,7 +349,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -401,7 +401,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -452,7 +452,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -504,7 +504,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -555,7 +555,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -789,7 +789,7 @@
 # name: test_altherma3m[select.altherma_domestichotwatertank_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Schedule',
+      'friendly_name': 'Altherma DomesticHotWaterTank Schedule',
       'icon': 'mdi:calendar-clock',
       'options': list([
         'User defined',
@@ -1350,7 +1350,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1401,7 +1401,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Heat up mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1458,7 +1458,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1517,7 +1517,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1576,7 +1576,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1635,7 +1635,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1688,7 +1688,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1745,7 +1745,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -1893,12 +1893,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1912,7 +1912,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 50.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -13096,12 +13096,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -13115,7 +13115,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -24299,12 +24299,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -24318,7 +24318,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -26757,12 +26757,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -26776,7 +26776,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 51.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -33936,7 +33936,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -33988,7 +33988,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
+      'friendly_name': 'Altherma Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34040,7 +34040,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34091,7 +34091,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34143,7 +34143,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
+      'friendly_name': 'Altherma Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -34194,7 +34194,7 @@
 # name: test_climate[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
+      'friendly_name': 'Altherma Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -39258,7 +39258,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
+      'friendly_name': 'Altherma Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -39315,7 +39315,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39374,7 +39374,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39433,7 +39433,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39492,7 +39492,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -39545,7 +39545,7 @@
 # name: test_climate[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -39602,7 +39602,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -44799,12 +44799,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -44818,7 +44818,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -67579,12 +67579,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'My Living Room',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'My Living Room',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -68718,12 +68718,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'NDJ',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'NDJ',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -68737,7 +68737,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'NDJ DomesticHotWaterFlowThrough NDJ',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough',
       'max_temp': 60.0,
       'min_temp': 35.0,
       'operation_list': list([
@@ -72067,12 +72067,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Vloerverwarming',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Vloerverwarming',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -72086,7 +72086,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 41.0,
-      'friendly_name': 'Vloerverwarming DomesticHotWaterTank Vloerverwarming',
+      'friendly_name': 'Vloerverwarming DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -73994,12 +73994,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -74013,7 +74013,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 53.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': None,
       'min_temp': None,
       'operation_list': list([
@@ -77367,7 +77367,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77419,7 +77419,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77471,7 +77471,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77522,7 +77522,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77574,7 +77574,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -77625,7 +77625,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -78884,7 +78884,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -78935,7 +78935,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Heat up mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -78992,7 +78992,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79051,7 +79051,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79110,7 +79110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79169,7 +79169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -79222,7 +79222,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -79279,7 +79279,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -79427,12 +79427,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Altherma',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Altherma',
+    'original_name': None,
     'platform': 'daikin_onecta',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -79446,7 +79446,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 53.0,
       'min_temp': 30.0,
       'operation_list': list([


### PR DESCRIPTION
    * custom_components/daikin_onecta/climate.py:
    * custom_components/daikin_onecta/water_heater.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Device names are now shown at the device level; entities use shorter, human-friendly labels.
  * Climate entities no longer include the device name as a prefix and show concise setpoint-derived names; device metadata displays the gateway/device name.
  * Water-heater labeling simplified: entity names are stabilized (no per-update renaming) and device-level name is used for clearer UI organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->