### PR TITLE
Upgraded minimum HA to 2026.5.0, dropped python 3.13 support

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v6"
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Upgrade pip
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v6"

--- a/custom_components/daikin_onecta/button.py
+++ b/custom_components/daikin_onecta/button.py
@@ -1,6 +1,4 @@
 """Component to interface with binary sensors."""
-from __future__ import annotations
-
 import logging
 
 from homeassistant.components.button import ButtonEntity

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 class OnectaRuntimeData:
     """Runtime Data for Onecta integration."""
 
-    coordinator: OnectaDataUpdateCoordinator
+    coordinator: "OnectaDataUpdateCoordinator"
     devices: dict[str, Any]
     daikin_api: DaikinApi
 

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -1,6 +1,4 @@
 """Coordinator for Daikin Onecta integration."""
-from __future__ import annotations
-
 import logging
 import random
 from dataclasses import dataclass

--- a/custom_components/daikin_onecta/diagnostics.py
+++ b/custom_components/daikin_onecta/diagnostics.py
@@ -1,6 +1,4 @@
 """Diagnostics support for Daikin Diagnostics."""
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data

--- a/custom_components/daikin_onecta/system_health.py
+++ b/custom_components/daikin_onecta/system_health.py
@@ -1,6 +1,4 @@
 """Provide info to system health."""
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.components import system_health

--- a/custom_components/daikin_onecta/update.py
+++ b/custom_components/daikin_onecta/update.py
@@ -1,6 +1,4 @@
 """Support for Daikin firmware update entities."""
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Daikin Onecta",
   "render_readme": true,
-  "homeassistant": "2025.10.2"
+  "homeassistant": "2026.5.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 # """Global fixtures for myenergi integration."""
-from __future__ import annotations
-
 import json
 import time
 from typing import Any


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Home Assistant compatibility requirement to 2026.5.0
* **Tests**
  * CI and pre-commit validation now run using Python 3.14 (replacing Python 3.13)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->