### PR TITLE
Simplify update by use attr instead of property

### DIFF
--- a/custom_components/daikin_onecta/update.py
+++ b/custom_components/daikin_onecta/update.py
@@ -107,35 +107,6 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
         # Populate initial state
         self._update_from_management_point(gateway_mp)
 
-    # ------------------------------------------------------------------
-    # UpdateEntity properties
-    # ------------------------------------------------------------------
-
-    @property
-    def installed_version(self) -> str | None:
-        """Return the currently installed firmware version."""
-        return self._installed_version
-
-    @property
-    def latest_version(self) -> str | None:
-        """Return the latest known firmware version."""
-        return self._latest_version
-
-    @property
-    def release_url(self) -> str | None:
-        """Point users to the Daikin support site for firmware info."""
-        return self._release_url
-
-    @property
-    def release_summary(self) -> str | None:
-        """Brief hint that the mobile app is used to apply updates."""
-        return self._release_summary
-
-    @property
-    def in_progress(self) -> bool | None:
-        """Is the update in progress."""
-        return self._in_progress
-
     async def async_install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         """Trigger a firmware update via the Daikin Onecta cloud API."""
         if self._firmware_id is None:
@@ -151,14 +122,14 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
             self._firmware_id,
         )
 
-        self._in_progress = True
+        self._attr_in_progress = True
         self.async_write_ha_state()
 
         result = await self._device.put(self._device.id, self._management_point_type, f"firmware/{self._firmware_id}", "")
 
         if not result:
             _LOGGER.error("Failed to trigger firmware update for %s", self._device.name)
-            self._in_progress = False
+            self._attr_in_progress = False
             self.async_write_ha_state()
 
     # ------------------------------------------------------------------
@@ -167,15 +138,15 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
 
     def _update_from_management_point(self, management_point: dict) -> None:
         """Pull the latest values out of a management point dict."""
-        self._installed_version: str | None = _get_value(management_point, "firmwareVersion")
-        if self._installed_version is None:
-            self._installed_version = _get_value(management_point, "softwareVersion")
+        self._attr_installed_version: str | None = _get_value(management_point, "firmwareVersion")
+        if self._attr_installed_version is None:
+            self._attr_installed_version = _get_value(management_point, "softwareVersion")
         self._is_update_supported: bool = bool(_get_value(management_point, "isFirmwareUpdateSupported"))
-        self._latest_version = self._installed_version
-        self._release_url = None
-        self._release_summary = None
+        self._attr_latest_version = self._attr_installed_version
+        self._attr_release_url = None
+        self._attr_release_summary = None
         self._firmware_id = None
-        self._in_progress = False
+        self._attr_in_progress = False
         self._attr_supported_features = UpdateEntityFeature.INSTALL
 
         firmwareUpdate = management_point.get("firmwareUpdate")
@@ -184,14 +155,14 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
             if firmwareUpdateValue is not None:
                 firmware_update_version = firmwareUpdateValue.get("version")
                 if firmware_update_version is not None:
-                    self._latest_version = firmware_update_version
-                self._release_summary = firmwareUpdateValue.get("description")
+                    self._attr_latest_version = firmware_update_version
+                self._attr_release_summary = firmwareUpdateValue.get("description")
                 self._firmware_id = firmwareUpdateValue.get("id")
         firmwareUpdateStatus = management_point.get("firmwareUpdateStatus")
         if firmwareUpdateStatus is not None:
             firmwareUpdateStatusValue = firmwareUpdateStatus.get("value")
             if firmwareUpdateStatusValue is not None:
-                self._in_progress = firmwareUpdateStatusValue == "in-progress"
+                self._attr_in_progress = firmwareUpdateStatusValue == "in-progress"
                 self._attr_supported_features |= UpdateEntityFeature.PROGRESS
 
     @callback

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -27876,7 +27876,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -27928,7 +27928,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -27980,7 +27980,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -28031,7 +28031,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -28083,7 +28083,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -28134,7 +28134,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -28595,7 +28595,7 @@
 # name: test_altherma_schedule[select.altherma_domestichotwatertank_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Schedule',
+      'friendly_name': 'Altherma DomesticHotWaterTank Schedule',
       'icon': 'mdi:calendar-clock',
       'options': list([
         'User defined',
@@ -29451,7 +29451,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29502,7 +29502,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Heat up mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -29559,7 +29559,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -29618,7 +29618,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -29677,7 +29677,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -29736,7 +29736,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -29789,7 +29789,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -29846,7 +29846,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -30141,7 +30141,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 51.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -75111,7 +75111,7 @@
 # name: test_holidaymode[binary_sensor.ndj_domestichotwaterflowthrough_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ Is holiday mode active',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -75163,7 +75163,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'NDJ Is in error state',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -75215,7 +75215,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'NDJ Is in warning state',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -75768,7 +75768,7 @@
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ Error code',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -75819,7 +75819,7 @@
 # name: test_holidaymode[sensor.ndj_domestichotwaterflowthrough_on_off_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'NDJ On/Off mode',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough On/Off mode',
       'icon': 'mdi:toggle-switch-variant',
     }),
     'context': <ANY>,
@@ -76162,7 +76162,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'NDJ',
+      'friendly_name': 'NDJ DomesticHotWaterFlowThrough',
       'max_temp': 60.0,
       'min_temp': 35.0,
       'operation_list': list([
@@ -85368,7 +85368,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -85420,7 +85420,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
+      'friendly_name': 'Altherma Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -85472,7 +85472,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -85523,7 +85523,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -85575,7 +85575,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
+      'friendly_name': 'Altherma Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -85626,7 +85626,7 @@
 # name: test_water_heater[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
+      'friendly_name': 'Altherma Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -86885,7 +86885,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
+      'friendly_name': 'Altherma Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -86936,7 +86936,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
+      'friendly_name': 'Altherma Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -86993,7 +86993,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -87052,7 +87052,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -87111,7 +87111,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -87170,7 +87170,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -87223,7 +87223,7 @@
 # name: test_water_heater[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -87280,7 +87280,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -87575,7 +87575,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank',
+      'friendly_name': 'Altherma',
       'max_temp': 53.0,
       'min_temp': 30.0,
       'operation_list': list([

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1501,6 +1501,8 @@ async def test_altherma_firmwareupdate(
     assert hass.states.get("update.climate_control_getr422_gateway_firmware_update").attributes["latest_version"] == "4.1.901"
     assert hass.states.get("update.climate_control_getr422_gateway_firmware_update").attributes["release_summary"] == "Altherma WLAN update 4.1.901"
     assert hass.states.get("update.climate_control_getr422_gateway_firmware_update").attributes["in_progress"] is True
+    assert hass.states.get("update.climate_control_getr422_userinterface_firmware_update").attributes["installed_version"] == "3.12.1"
+    assert hass.states.get("update.climate_control_getr422_userinterface_firmware_update").attributes["latest_version"] == "3.12.1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
    * custom_components/daikin_onecta/update.py:
    * tests/snapshots/test_init.ambr:
    * tests/test_init.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated firmware update entity to align with Home Assistant's standard attribute structure.

* **Tests**
  * Updated test snapshots to reflect enhanced entity naming for Altherma and NDJ components.
  * Added verification for firmware version information retrieval.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwillemsen/daikin_onecta/pull/655)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->