### PR TITLE
Add French translations for water heater and climate

### DIFF
--- a/custom_components/daikin_onecta/translations/fr.json
+++ b/custom_components/daikin_onecta/translations/fr.json
@@ -1,4 +1,23 @@
 {
+  "entity": {
+    "water_heater": {
+      "hot_water_tank": {
+        "state": {
+          "off": "Arrêt",
+          "heat_pump": "Normal",
+          "performance": "Boost"
+        }
+      }
+    },
+    "climate": {
+      "leavingwateroffset": {
+        "state": {
+          "off": "Arrêt",
+          "cool": "Frais"
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION

<img width="563" height="1218" alt="Capture d’écran 2026-05-22 à 09 55 59" src="https://github.com/user-attachments/assets/475296f3-56f9-4f2c-bf39-d86957c2b51f" />

Shorter translations than the default ones.

Use case : 
- On mobile
- Using half-column tiles (so you can have 2 tiles in a row)
- Displaying the State (function mode) *and* the (water) Temperature in "State"

In that configuration, the default translations are too long and the temperature gets hidden.

With those shorter words, both informations can be displayed under the Name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added French translations for water heater and climate device status indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwillemsen/daikin_onecta/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->