### PR TITLE
Add HomeKit optional compatibility mode

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -69,6 +69,7 @@ async def update_listener(hass, config_entry):
     onecta_data: OnectaRuntimeData = config_entry.runtime_data
     coordinator = onecta_data.coordinator
     coordinator.update_settings(config_entry)
+    coordinator.async_update_listeners()
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -7,6 +7,10 @@ from datetime import timedelta
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate import FAN_HIGH
+from homeassistant.components.climate import FAN_LOW
+from homeassistant.components.climate import FAN_MEDIUM
+from homeassistant.components.climate import FAN_MIDDLE
 from homeassistant.components.climate import PLATFORM_SCHEMA
 from homeassistant.components.climate.const import ATTR_HVAC_MODE
 from homeassistant.components.climate.const import ClimateEntityFeature
@@ -26,6 +30,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import CONF_HOMEKIT_FAN_MODE_ALIASES
 from .const import DOMAIN
 from .const import FANMODE_FIXED
 from .const import TRANSLATION_KEY
@@ -37,6 +42,14 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_HOST): cv.string, vol.Optional(CONF_NAME): cv.string})
 
 PRESET_MODES = {PRESET_COMFORT, PRESET_ECO, PRESET_AWAY, PRESET_BOOST}
+
+DAIKIN_FAN_MODE_QUIET = "quiet"
+
+HOMEKIT_FIXED_FAN_MODE_ALIASES = {
+    FAN_MIDDLE: "2",
+    FAN_MEDIUM: "3",
+    FAN_HIGH: "5",
+}
 
 HA_HVAC_TO_DAIKIN = {
     HVACMode.FAN_ONLY: "fanOnly",
@@ -173,6 +186,52 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         if cc is not None:
             om = cc.get("operationMode")
         return om
+
+    @property
+    def _homekit_fan_mode_aliases_enabled(self):
+        return self.coordinator.options.get(CONF_HOMEKIT_FAN_MODE_ALIASES, False)
+
+    def _homekit_fan_mode_aliases(self, fan_speed):
+        aliases = {}
+        if not self._homekit_fan_mode_aliases_enabled:
+            return aliases
+
+        current_mode = fan_speed.get("currentMode", {})
+        current_mode_values = current_mode.get("values", [])
+        if DAIKIN_FAN_MODE_QUIET in current_mode_values:
+            aliases[FAN_LOW] = DAIKIN_FAN_MODE_QUIET
+
+        if FANMODE_FIXED not in current_mode_values:
+            return aliases
+
+        fixed_mode = fan_speed.get("modes", {}).get(FANMODE_FIXED)
+        if fixed_mode is None:
+            return aliases
+
+        min_val = int(fixed_mode["minValue"])
+        max_val = int(fixed_mode["maxValue"])
+        step_value = int(fixed_mode["stepValue"])
+        fixed_values = {str(val) for val in range(min_val, max_val + 1, step_value)}
+
+        for alias, daikin_mode in HOMEKIT_FIXED_FAN_MODE_ALIASES.items():
+            if daikin_mode in fixed_values:
+                aliases[alias] = daikin_mode
+
+        return aliases
+
+    def _get_homekit_fan_mode(self, fan_speed, fan_mode):
+        if not self._homekit_fan_mode_aliases_enabled:
+            return fan_mode
+
+        aliases = self._homekit_fan_mode_aliases(fan_speed)
+        for alias, daikin_mode in aliases.items():
+            if fan_mode == daikin_mode:
+                return alias
+
+        return fan_mode
+
+    def _resolve_homekit_fan_mode_alias(self, fan_speed, fan_mode):
+        return self._homekit_fan_mode_aliases(fan_speed).get(fan_mode, fan_mode)
 
     def setpoint(self):
         setpoint = None
@@ -489,6 +548,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
                             fan_mode = str(fixedModes["value"])
                     else:
                         fan_mode = mode
+                    fan_mode = self._get_homekit_fan_mode(fan_speed, fan_mode)
 
         _LOGGER.info(
             "Device '%s' has fan mode '%s'",
@@ -522,6 +582,9 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
                                     fan_modes.append(str(val))
                         else:
                             fan_modes.append(c)
+                    for alias in self._homekit_fan_mode_aliases(fan_speed):
+                        if alias not in fan_modes:
+                            fan_modes.append(alias)
 
         _LOGGER.info(
             "Device '%s' has fan modes '%s'",
@@ -533,6 +596,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode):
         """Set the fan mode"""
+        fan_mode = str(fan_mode)
         _LOGGER.debug(
             "Device '%s' request to set fan_mode to '%s'",
             self._device.name,
@@ -542,10 +606,13 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         res = True
         cc = self.climate_control()
         operationmode = cc["operationMode"]["value"]
+        fan_control = cc.get("fanControl")
+        fan_speed = fan_control["value"]["operationModes"][operationmode].get("fanSpeed")
+        requested_fan_mode = fan_mode
+        fan_mode = self._resolve_homekit_fan_mode_alias(fan_speed, fan_mode)
         if fan_mode.isnumeric():
-            if not self._attr_fan_mode.isnumeric():
-                # Only set the currentMode to fixed when we currently don't have set
-                # a numeric mode
+            if fan_speed["currentMode"]["value"] != FANMODE_FIXED:
+                # Only set currentMode to fixed when it isn't already fixed.
                 res = await self._device.patch(
                     self._device.id,
                     self._embedded_id,
@@ -589,7 +656,12 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
                 )
 
         if res is True:
-            self._attr_fan_mode = fan_mode
+            if fan_mode.isnumeric():
+                fan_speed["currentMode"]["value"] = FANMODE_FIXED
+                fan_speed["modes"][FANMODE_FIXED]["value"] = int(fan_mode)
+            else:
+                fan_speed["currentMode"]["value"] = fan_mode
+            self._attr_fan_mode = requested_fan_mode
             self.async_write_ha_state()
 
         return res

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -189,9 +189,11 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def _homekit_fan_mode_aliases_enabled(self):
+        """Return whether HomeKit fan mode aliases are enabled."""
         return self.coordinator.options.get(CONF_HOMEKIT_FAN_MODE_ALIASES, False)
 
     def _homekit_fan_mode_aliases(self, fan_speed):
+        """Return HomeKit fan mode aliases available for the fan speed data."""
         aliases = {}
         if not self._homekit_fan_mode_aliases_enabled:
             return aliases
@@ -220,6 +222,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         return aliases
 
     def _get_homekit_fan_mode(self, fan_speed, fan_mode):
+        """Return the HomeKit alias for a Daikin fan mode when available."""
         if not self._homekit_fan_mode_aliases_enabled:
             return fan_mode
 
@@ -231,6 +234,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         return fan_mode
 
     def _resolve_homekit_fan_mode_alias(self, fan_speed, fan_mode):
+        """Return the Daikin fan mode represented by a HomeKit alias."""
         return self._homekit_fan_mode_aliases(fan_speed).get(fan_mode, fan_mode)
 
     def setpoint(self):

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -12,11 +12,13 @@ from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.selector import BooleanSelector
 from homeassistant.helpers.selector import NumberSelector
 from homeassistant.helpers.selector import NumberSelectorConfig
 from homeassistant.helpers.selector import TimeSelector
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
+from .const import CONF_HOMEKIT_FAN_MODE_ALIASES
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +67,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): NumberSelector(
                         NumberSelectorConfig(min=20, max=300, step=1),
                     ),
+                    vol.Required(
+                        CONF_HOMEKIT_FAN_MODE_ALIASES,
+                        default=self.options.get(CONF_HOMEKIT_FAN_MODE_ALIASES, False),
+                    ): BooleanSelector(),
                 }
             ),
             errors=errors,

--- a/custom_components/daikin_onecta/const.py
+++ b/custom_components/daikin_onecta/const.py
@@ -25,6 +25,8 @@ DAIKIN_API_URL = "https://api.onecta.daikineurope.com"
 
 SCHEDULE_OFF = "off"
 
+CONF_HOMEKIT_FAN_MODE_ALIASES = "homekit_fan_mode_aliases"
+
 FANMODE_FIXED = "fixed"
 
 SENSOR_PERIOD_DAILY = "d"

--- a/custom_components/daikin_onecta/strings.json
+++ b/custom_components/daikin_onecta/strings.json
@@ -35,7 +35,8 @@
           "low_scan_interval": "Low frequency period update interval (minutes)",
           "high_scan_start": "High frequency period start time",
           "low_scan_start": "Low frequency period start time",
-          "scan_ignore": "Number of seconds that a data refresh is ignored after a command"
+          "scan_ignore": "Number of seconds that a data refresh is ignored after a command",
+          "homekit_fan_mode_aliases": "Expose HomeKit compatible fan speed aliases"
         },
         "description": "Configure Daikin Onecta Cloud polling",
         "title": "Daikin Onecta"

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -7,7 +7,8 @@
           "low_scan_interval": "Low frequency period update interval (minutes)",
           "high_scan_start": "High frequency period start time",
           "low_scan_start": "Low frequency period start time",
-          "scan_ignore": "Number of seconds that a data refresh is ignored after a command"
+          "scan_ignore": "Number of seconds that a data refresh is ignored after a command",
+          "homekit_fan_mode_aliases": "Expose HomeKit compatible fan speed aliases"
         },
         "description": "Configure Daikin Onecta Cloud polling",
         "title": "Daikin Onecta"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .conftest import FAKE_ACCESS_TOKEN
+from custom_components.daikin_onecta.const import CONF_HOMEKIT_FAN_MODE_ALIASES
 from custom_components.daikin_onecta.const import DOMAIN
 from custom_components.daikin_onecta.const import OAUTH2_AUTHORIZE
 from custom_components.daikin_onecta.const import OAUTH2_TOKEN
@@ -101,6 +102,32 @@ async def test_config_entry_unique_id_migration(
 
     assert config_entry_v1_1.unique_id == "1234567890"
     assert config_entry_v1_1.minor_version == 2
+
+
+async def test_options_flow_homekit_fan_mode_aliases_default(
+    hass: HomeAssistant,
+) -> None:
+    """Test HomeKit fan mode aliases option defaults to disabled."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "high_scan_interval": 10,
+            "low_scan_interval": 30,
+            "high_scan_start": "07:00:00",
+            "low_scan_start": "22:00:00",
+            "scan_ignore": 30,
+            CONF_HOMEKIT_FAN_MODE_ALIASES: False,
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_HOMEKIT_FAN_MODE_ALIASES] is False
 
 
 ZEROCONF_DISCOVERY = ZeroconfServiceInfo(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 from datetime import date
 from datetime import timedelta
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import homeassistant.helpers.device_registry as dr
@@ -56,8 +57,11 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClien
 from pytest_homeassistant_custom_component.test_util.aiohttp import URL
 from syrupy import SnapshotAssertion
 
+from .conftest import FAKE_ACCESS_TOKEN
 from .conftest import load_fixture_json
 from .conftest import snapshot_platform_entities
+from custom_components.daikin_onecta import update_listener
+from custom_components.daikin_onecta.climate import DaikinClimate
 from custom_components.daikin_onecta.const import CONF_HOMEKIT_FAN_MODE_ALIASES
 from custom_components.daikin_onecta.const import DAIKIN_API_URL
 from custom_components.daikin_onecta.const import SCHEDULE_OFF
@@ -129,7 +133,7 @@ async def test_fanmode(
 
     with patch(
         "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
-        return_value="XXXXXX",
+        return_value=FAKE_ACCESS_TOKEN,
     ):
         assert hass.states.get("climate.Sala_room_temperature").state == HVACMode.OFF
         assert hass.states.get("climate.Sala_room_temperature").attributes["fan_mode"] == "auto"
@@ -440,7 +444,57 @@ async def test_climate_homekit_fan_mode_aliases(
         await hass.async_block_till_done()
 
         assert aioclient_mock.mock_calls[-1][2] == '{"value": 3, "path": "/operationModes/heating/fanSpeed/modes/fixed"}'
-        assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == "3"
+    assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == "3"
+
+
+async def test_update_listener_notifies_entities() -> None:
+    """Test options updates notify coordinator listeners."""
+    coordinator = MagicMock()
+    config_entry = MagicMock()
+    config_entry.runtime_data = MagicMock(coordinator=coordinator)
+
+    await update_listener(None, config_entry)
+
+    coordinator.update_settings.assert_called_once_with(config_entry)
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+def test_homekit_fan_mode_alias_helpers() -> None:
+    """Test HomeKit fan mode alias helper edge cases."""
+    climate = DaikinClimate.__new__(DaikinClimate)
+    climate.coordinator = MagicMock(options={CONF_HOMEKIT_FAN_MODE_ALIASES: True})
+
+    assert climate._homekit_fan_mode_aliases(
+        {
+            "currentMode": {
+                "values": ["quiet", "auto"],
+            },
+        }
+    ) == {FAN_LOW: "quiet"}
+
+    assert climate._homekit_fan_mode_aliases(
+        {
+            "currentMode": {
+                "values": ["quiet", "auto", "fixed"],
+            },
+            "modes": {},
+        }
+    ) == {FAN_LOW: "quiet"}
+
+    fan_speed = {
+        "currentMode": {
+            "values": ["quiet", "auto", "fixed"],
+        },
+        "modes": {
+            "fixed": {
+                "minValue": 1,
+                "maxValue": 5,
+                "stepValue": 1,
+            },
+        },
+    }
+    assert climate._get_homekit_fan_mode(fan_speed, "4") == "4"
+    assert climate._resolve_homekit_fan_mode_alias(fan_speed, FAN_HIGH) == "5"
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,6 +15,10 @@ from homeassistant.components.climate import ATTR_PRESET_MODE
 from homeassistant.components.climate import ATTR_SWING_HORIZONTAL_MODE
 from homeassistant.components.climate import ATTR_SWING_MODE
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate import FAN_HIGH
+from homeassistant.components.climate import FAN_LOW
+from homeassistant.components.climate import FAN_MEDIUM
+from homeassistant.components.climate import FAN_MIDDLE
 from homeassistant.components.climate import PRESET_AWAY
 from homeassistant.components.climate import PRESET_BOOST
 from homeassistant.components.climate import PRESET_NONE
@@ -54,6 +58,7 @@ from syrupy import SnapshotAssertion
 
 from .conftest import load_fixture_json
 from .conftest import snapshot_platform_entities
+from custom_components.daikin_onecta.const import CONF_HOMEKIT_FAN_MODE_ALIASES
 from custom_components.daikin_onecta.const import DAIKIN_API_URL
 from custom_components.daikin_onecta.const import SCHEDULE_OFF
 from custom_components.daikin_onecta.coordinator import OnectaRuntimeData
@@ -358,6 +363,84 @@ async def test_climate_fixedfanmode(
     await snapshot_platform_entities(hass, aioclient_mock, config_entry, Platform.SENSOR, entity_registry, snapshot, "climate_fixedfanmode")
 
     assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == "3"
+    fan_modes = hass.states.get("climate.werkkamer_room_temperature").attributes["fan_modes"]
+    assert FAN_LOW not in fan_modes
+    assert FAN_MIDDLE not in fan_modes
+    assert FAN_MEDIUM not in fan_modes
+    assert FAN_HIGH not in fan_modes
+
+
+@pytest.mark.asyncio
+async def test_climate_homekit_fan_mode_aliases(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    onecta_auth: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test HomeKit fan mode aliases."""
+    hass.config_entries.async_update_entry(config_entry, options={CONF_HOMEKIT_FAN_MODE_ALIASES: True})
+
+    await snapshot_platform_entities(hass, aioclient_mock, config_entry, Platform.SENSOR, entity_registry, snapshot, "climate_fixedfanmode")
+
+    state = hass.states.get("climate.werkkamer_room_temperature")
+    assert state.attributes["fan_mode"] == FAN_MEDIUM
+    assert state.attributes["fan_modes"] == ["auto", "quiet", "1", "2", "3", "4", "5", FAN_LOW, FAN_MIDDLE, FAN_MEDIUM, FAN_HIGH]
+
+    with patch(
+        "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
+        return_value="XXXXXX",
+    ):
+        aioclient_mock.patch(
+            DAIKIN_API_URL + "/v1/gateway-devices/6f944461-08cb-4fee-979c-710ff66cea77/management-points/climateControl/characteristics/fanControl",
+            status=204,
+        )
+
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: "climate.werkkamer_room_temperature", ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert aioclient_mock.mock_calls[-1][2] == '{"value": "quiet", "path": "/operationModes/heating/fanSpeed/currentMode"}'
+        assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == FAN_LOW
+
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: "climate.werkkamer_room_temperature", ATTR_FAN_MODE: FAN_MIDDLE},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert aioclient_mock.mock_calls[-2][2] == '{"value": "fixed", "path": "/operationModes/heating/fanSpeed/currentMode"}'
+        assert aioclient_mock.mock_calls[-1][2] == '{"value": 2, "path": "/operationModes/heating/fanSpeed/modes/fixed"}'
+        assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == FAN_MIDDLE
+
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: "climate.werkkamer_room_temperature", ATTR_FAN_MODE: FAN_HIGH},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert aioclient_mock.mock_calls[-1][2] == '{"value": 5, "path": "/operationModes/heating/fanSpeed/modes/fixed"}'
+        assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == FAN_HIGH
+
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: "climate.werkkamer_room_temperature", ATTR_FAN_MODE: 3},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert aioclient_mock.mock_calls[-1][2] == '{"value": 3, "path": "/operationModes/heating/fanSpeed/modes/fixed"}'
+        assert hass.states.get("climate.werkkamer_room_temperature").attributes["fan_mode"] == "3"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added an opt-in `homekit_fan_mode_aliases` option to expose HomeKit-compatible climate fan speed names without changing the default Home Assistant UI behavior.

When enabled, the integration keeps existing Daikin fan modes but also exposes low, middle, medium, and high for HomeKit. The mapping is:

`low` -> `quiet`
`middle` -> fixed speed `2`
`medium` -> fixed speed `3`
`high` -> fixed speed `5`

Existing numeric fan mode service calls continue to work. The default remains disabled so users who only use Home Assistant do not see any extra fan mode values.

Tests were added for default behavior, opt-in alias behavior, and the options flow.

Related issues https://github.com/jwillemsen/daikin_onecta/issues/374 https://github.com/home-assistant/core/issues/131884 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HomeKit-compatible fan speed aliases, including a "quiet" alias for Daikin HVAC units.

* **Configuration**
  * New toggle in the integration options to enable HomeKit fan mode aliases.

* **Bug Fixes**
  * Options changes now trigger an immediate refresh so updated settings take effect.

* **Documentation**
  * Added UI text and translation for the new fan mode aliases option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwillemsen/daikin_onecta/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->