### PR TITLE
Add missing invalid_token and unknown abort translations to en.json

### DIFF
--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -20,6 +20,8 @@
       "already_configured": "The integration is already configured.",
       "cannot_connect": "Failed to connect to Daikin Cloud.",
       "init_failed": "Failed to initialize Daikin API.",
+      "invalid_token": "Invalid or expired token; please reconfigure the integration.",
+      "unknown": "An unexpected error occurred.",
       "wrong_account": "Please ensure you reconfigure against the same account."
     },
     "error": {

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -21,7 +21,7 @@
       "cannot_connect": "Failed to connect to Daikin Cloud.",
       "init_failed": "Failed to initialize Daikin API.",
       "invalid_token": "Invalid or expired token; please reconfigure the integration.",
-      "unknown": "An unexpected error occurred.",
+      "unknown": "Failed due to an unexpected error.",
       "wrong_account": "Please ensure you reconfigure against the same account."
     },
     "error": {


### PR DESCRIPTION
Adds the missing `invalid_token` and `unknown` abort translation strings to `custom_components/daikin_onecta/translations/en.json`.

The config flow already uses these abort reasons in `config_flow.py` (lines 108 and 157), so without these translation entries Home Assistant displays the raw abort code instead of a user-friendly message.

Fixes #669


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new error message translations for invalid token and unknown error scenarios in the authentication setup process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwillemsen/daikin_onecta/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->