### PR TITLE
Add logging whether swing is settable when we retrieve it

### DIFF
--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -672,6 +672,7 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
 
     def __get_swing_mode(self, direction):
         swingMode = ""
+        settable = False
         cc = self.climate_control()
         fanControl = cc.get("fanControl")
         if fanControl is not None:
@@ -682,13 +683,15 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
                 if fan_direction is not None:
                     fd = fan_direction.get(direction)
                     if fd is not None:
+                        settable = fd["currentMode"].get("settable", False)
                         swingMode = fd["currentMode"]["value"].lower()
 
         _LOGGER.info(
-            "Device '%s' has %s swing mode '%s'",
+            "Device '%s' has %s swing mode '%s' and is settable %s",
             self._device.name,
             direction,
             swingMode,
+            settable,
         )
 
         return swingMode


### PR DESCRIPTION
    * custom_components/daikin_onecta/climate.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved swing mode status tracking to properly report when swing direction adjustment is available on Daikin climate devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwillemsen/daikin_onecta/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->