### PR TITLE
Warn when a successful PATCH is reverted by the cloud or unit

### DIFF
--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -24,6 +24,7 @@ REVERT_CHECK_TTL = timedelta(minutes=5)
 
 @dataclass
 class _PendingWrite:
+
     """A successful PATCH whose effect has not yet been observed via the cloud."""
 
     embedded_id: str

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -24,7 +24,6 @@ REVERT_CHECK_TTL = timedelta(minutes=5)
 
 @dataclass
 class _PendingWrite:
-
     """A successful PATCH whose effect has not yet been observed via the cloud."""
 
     embedded_id: str

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -129,31 +129,35 @@ class DaikinOnectaDevice:
         self._check_pending_writes()
 
     def _read_value(self, embedded_id, data_point, data_point_path):
-        """Return the current value at the given characteristic path.
+        """Return the current value at the given characteristic path, or _MISSING if absent."""
+        management_point = self._find_management_point(embedded_id)
+        if management_point is None:
+            return _MISSING
+        characteristic = management_point.get(data_point)
+        if characteristic is None:
+            return _MISSING
+        node = characteristic.get("value", _MISSING)
+        if data_point_path:
+            node = self._walk_path(node, data_point_path)
+        if isinstance(node, dict):
+            return node.get("value", _MISSING)
+        return node
 
-        The characteristic value is stored under ``managementPoint[data_point]["value"]``.
-        For nested writes (``data_point_path`` like ``/operationModes/auto/fanSpeed/currentMode``)
-        we walk that path inside the characteristic value and read the final ``value`` field.
-        Returns the sentinel ``_MISSING`` when the path is not present in the payload, so that
-        an explicit ``None`` value coming from the cloud can still be compared correctly.
-        """
+    def _find_management_point(self, embedded_id):
+        """Return the management point with the given embedded id, or None."""
         for management_point in self.daikin_data.get("managementPoints", []):
-            if management_point.get("embeddedId") != embedded_id:
-                continue
-            characteristic = management_point.get(data_point)
-            if characteristic is None:
+            if management_point.get("embeddedId") == embedded_id:
+                return management_point
+        return None
+
+    @staticmethod
+    def _walk_path(node, path):
+        """Follow ``path`` (``/a/b/c``) inside ``node`` and return the resulting subtree or _MISSING."""
+        for segment in path.strip("/").split("/"):
+            if not isinstance(node, dict) or segment not in node:
                 return _MISSING
-            if not data_point_path:
-                return characteristic.get("value", _MISSING)
-            node = characteristic.get("value")
-            for segment in data_point_path.strip("/").split("/"):
-                if not isinstance(node, dict) or segment not in node:
-                    return _MISSING
-                node = node[segment]
-            if isinstance(node, dict):
-                return node.get("value", _MISSING)
-            return node
-        return _MISSING
+            node = node[segment]
+        return node
 
     def _check_pending_writes(self):
         """Warn when a previously accepted PATCH has been reverted by the cloud/unit."""

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -24,8 +24,6 @@ REVERT_CHECK_TTL = timedelta(minutes=5)
 
 @dataclass
 class _PendingWrite:
-    """A successful PATCH whose effect has not yet been observed via the cloud."""
-
     embedded_id: str
     data_point: str
     data_point_path: str

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from datetime import datetime
+from datetime import timedelta
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -7,6 +9,11 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long to keep watching for a silent revert after a successful PATCH.
+# After this period we stop checking the pending write to avoid false positives
+# caused by legitimate user changes via the wired controller or the Onecta app.
+REVERT_CHECK_TTL = timedelta(minutes=5)
 
 
 class DaikinOnectaDevice:
@@ -19,6 +26,11 @@ class DaikinOnectaDevice:
         self.daikin_data = jsonData
         self.id = self.daikin_data["id"]
         self.name = self.daikin_data["deviceModel"]
+        # Successful PATCH writes for which we have not yet observed the
+        # resulting value via a coordinator refresh. Used to warn the user
+        # when the Daikin cloud, gateway or wired master controller silently
+        # reverts a change.
+        self._pending_writes: list[dict] = []
 
         management_points = self.daikin_data.get("managementPoints", [])
         for management_point in management_points:
@@ -95,6 +107,66 @@ class DaikinOnectaDevice:
         """Overwrite the json data for this device."""
         self.daikin_data = desc
         _LOGGER.info("Device '%s' received new data from the Daikin cloud, isCloudConnectionUp '%s'", self.name, self.available)
+        self._check_pending_writes()
+
+    def _read_value(self, embedded_id, data_point, data_point_path):
+        """Return the current value at the given characteristic path, or None.
+
+        The characteristic value is stored under ``managementPoint[data_point]["value"]``.
+        For nested writes (``data_point_path`` like ``/operationModes/auto/fanSpeed/currentMode``)
+        we walk that path inside the characteristic value and read the final ``value`` field.
+        """
+        for management_point in self.daikin_data.get("managementPoints", []):
+            if management_point.get("embeddedId") != embedded_id:
+                continue
+            characteristic = management_point.get(data_point)
+            if characteristic is None:
+                return None
+            if not data_point_path:
+                return characteristic.get("value")
+            node = characteristic.get("value")
+            for segment in data_point_path.strip("/").split("/"):
+                if not isinstance(node, dict):
+                    return None
+                node = node.get(segment)
+                if node is None:
+                    return None
+            if isinstance(node, dict):
+                return node.get("value")
+            return node
+        return None
+
+    def _check_pending_writes(self):
+        """Warn when a previously accepted PATCH has been reverted by the cloud/unit."""
+        if not self._pending_writes:
+            return
+        now = datetime.now()
+        remaining: list[dict] = []
+        for pending in self._pending_writes:
+            if now - pending["set_at"] > REVERT_CHECK_TTL:
+                # Stop watching expired entries silently.
+                continue
+            actual = self._read_value(pending["embedded_id"], pending["data_point"], pending["data_point_path"])
+            if actual is None:
+                # Value not present yet in the new payload, keep watching.
+                remaining.append(pending)
+                continue
+            if actual == pending["value"]:
+                # The write took effect, stop watching this entry.
+                continue
+            _LOGGER.warning(
+                "Device '%s' value at %s/%s%s was set to '%s' but the Daikin cloud now reports '%s'. "
+                "The unit, gateway or a wired master controller (for example a BRC1H) most likely reverted "
+                "the change. Check the master controller's operation mode lock / cool-heat selection setting.",
+                self.name,
+                pending["embedded_id"],
+                pending["data_point"],
+                pending["data_point_path"] or "",
+                pending["value"],
+                actual,
+            )
+            # Warn only once per pending write, then drop it.
+        self._pending_writes = remaining
 
     async def patch(self, id, embeddedId, dataPoint, dataPointPath, value):
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/characteristics/" + dataPoint
@@ -108,6 +180,17 @@ class DaikinOnectaDevice:
         res = await self.api.doBearerRequest("PATCH", setPath, setOptions)
 
         _LOGGER.info("Result: {}".format(res))
+
+        if res is True:
+            self._pending_writes.append(
+                {
+                    "embedded_id": embeddedId,
+                    "data_point": dataPoint,
+                    "data_point_path": dataPointPath,
+                    "value": value,
+                    "set_at": datetime.now(),
+                }
+            )
 
         return res
 

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -11,6 +11,11 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel returned by _read_value when the requested characteristic/path is not
+# present in the device payload, so we can distinguish that from an explicit
+# ``None`` value that the cloud actually reports.
+_MISSING = object()
+
 # How long to keep watching for a silent revert after a successful PATCH.
 # After this period we stop checking the pending write to avoid false positives
 # caused by legitimate user changes via the wired controller or the Onecta app.
@@ -124,31 +129,31 @@ class DaikinOnectaDevice:
         self._check_pending_writes()
 
     def _read_value(self, embedded_id, data_point, data_point_path):
-        """Return the current value at the given characteristic path, or None.
+        """Return the current value at the given characteristic path.
 
         The characteristic value is stored under ``managementPoint[data_point]["value"]``.
         For nested writes (``data_point_path`` like ``/operationModes/auto/fanSpeed/currentMode``)
         we walk that path inside the characteristic value and read the final ``value`` field.
+        Returns the sentinel ``_MISSING`` when the path is not present in the payload, so that
+        an explicit ``None`` value coming from the cloud can still be compared correctly.
         """
         for management_point in self.daikin_data.get("managementPoints", []):
             if management_point.get("embeddedId") != embedded_id:
                 continue
             characteristic = management_point.get(data_point)
             if characteristic is None:
-                return None
+                return _MISSING
             if not data_point_path:
-                return characteristic.get("value")
+                return characteristic.get("value", _MISSING)
             node = characteristic.get("value")
             for segment in data_point_path.strip("/").split("/"):
-                if not isinstance(node, dict):
-                    return None
-                node = node.get(segment)
-                if node is None:
-                    return None
+                if not isinstance(node, dict) or segment not in node:
+                    return _MISSING
+                node = node[segment]
             if isinstance(node, dict):
-                return node.get("value")
+                return node.get("value", _MISSING)
             return node
-        return None
+        return _MISSING
 
     def _check_pending_writes(self):
         """Warn when a previously accepted PATCH has been reverted by the cloud/unit."""
@@ -161,7 +166,7 @@ class DaikinOnectaDevice:
                 # Stop watching expired entries silently.
                 continue
             actual = self._read_value(pending.embedded_id, pending.data_point, pending.data_point_path)
-            if actual is None:
+            if actual is _MISSING:
                 # Value not present yet in the new payload, keep watching.
                 remaining[key] = pending
                 continue

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 
@@ -16,6 +17,17 @@ _LOGGER = logging.getLogger(__name__)
 REVERT_CHECK_TTL = timedelta(minutes=5)
 
 
+@dataclass
+class _PendingWrite:
+    """A successful PATCH whose effect has not yet been observed via the cloud."""
+
+    embedded_id: str
+    data_point: str
+    data_point_path: str
+    value: object
+    set_at: datetime
+
+
 class DaikinOnectaDevice:
     """Class to represent and control one Daikin Onecta Device."""
 
@@ -29,8 +41,10 @@ class DaikinOnectaDevice:
         # Successful PATCH writes for which we have not yet observed the
         # resulting value via a coordinator refresh. Used to warn the user
         # when the Daikin cloud, gateway or wired master controller silently
-        # reverts a change.
-        self._pending_writes: list[dict] = []
+        # reverts a change. Keyed by (embedded_id, data_point, data_point_path)
+        # so a newer PATCH to the same characteristic supersedes the previous
+        # one and we do not warn about writes that were intentionally replaced.
+        self._pending_writes: dict[tuple[str, str, str], _PendingWrite] = {}
 
         management_points = self.daikin_data.get("managementPoints", [])
         for management_point in management_points:
@@ -141,17 +155,17 @@ class DaikinOnectaDevice:
         if not self._pending_writes:
             return
         now = datetime.now()
-        remaining: list[dict] = []
-        for pending in self._pending_writes:
-            if now - pending["set_at"] > REVERT_CHECK_TTL:
+        remaining: dict[tuple[str, str, str], _PendingWrite] = {}
+        for key, pending in self._pending_writes.items():
+            if now - pending.set_at > REVERT_CHECK_TTL:
                 # Stop watching expired entries silently.
                 continue
-            actual = self._read_value(pending["embedded_id"], pending["data_point"], pending["data_point_path"])
+            actual = self._read_value(pending.embedded_id, pending.data_point, pending.data_point_path)
             if actual is None:
                 # Value not present yet in the new payload, keep watching.
-                remaining.append(pending)
+                remaining[key] = pending
                 continue
-            if actual == pending["value"]:
+            if actual == pending.value:
                 # The write took effect, stop watching this entry.
                 continue
             _LOGGER.warning(
@@ -159,10 +173,10 @@ class DaikinOnectaDevice:
                 "The unit, gateway or a wired master controller (for example a BRC1H) most likely reverted "
                 "the change. Check the master controller's operation mode lock / cool-heat selection setting.",
                 self.name,
-                pending["embedded_id"],
-                pending["data_point"],
-                pending["data_point_path"] or "",
-                pending["value"],
+                pending.embedded_id,
+                pending.data_point,
+                pending.data_point_path or "",
+                pending.value,
                 actual,
             )
             # Warn only once per pending write, then drop it.
@@ -182,14 +196,15 @@ class DaikinOnectaDevice:
         _LOGGER.info("Result: {}".format(res))
 
         if res is True:
-            self._pending_writes.append(
-                {
-                    "embedded_id": embeddedId,
-                    "data_point": dataPoint,
-                    "data_point_path": dataPointPath,
-                    "value": value,
-                    "set_at": datetime.now(),
-                }
+            # Replace any previous pending write for the same characteristic so
+            # superseded values do not generate a false revert warning.
+            key = (embeddedId, dataPoint, dataPointPath or "")
+            self._pending_writes[key] = _PendingWrite(
+                embedded_id=embeddedId,
+                data_point=dataPoint,
+                data_point_path=dataPointPath or "",
+                value=value,
+                set_at=datetime.now(),
             )
 
         return res

--- a/tests/test_device_pending_writes.py
+++ b/tests/test_device_pending_writes.py
@@ -1,0 +1,175 @@
+"""Unit tests for DaikinOnectaDevice silent-revert detection."""
+import logging
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.daikin_onecta.device import _MISSING
+from custom_components.daikin_onecta.device import _PendingWrite
+from custom_components.daikin_onecta.device import DaikinOnectaDevice
+from custom_components.daikin_onecta.device import REVERT_CHECK_TTL
+
+
+def _make_device(operation_mode="auto", fan_current_mode="auto"):
+    api = AsyncMock()
+    api.doBearerRequest = AsyncMock(return_value=True)
+    json_data = {
+        "id": "dev-1",
+        "deviceModel": "dx23",
+        "isCloudConnectionUp": {"value": True},
+        "managementPoints": [
+            {
+                "embeddedId": "climateControl",
+                "managementPointType": "climateControl",
+                "name": {"value": "Woonkamer"},
+                "operationMode": {"settable": True, "values": ["auto", "cooling"], "value": operation_mode},
+                "fanControl": {
+                    "value": {
+                        "operationModes": {
+                            "auto": {
+                                "fanSpeed": {
+                                    "currentMode": {"settable": True, "value": fan_current_mode, "values": ["auto", "fixed"]},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    }
+    return DaikinOnectaDevice(json_data, api), api
+
+
+def _new_payload(operation_mode_value, fan_current_mode_value=None, drop_fan=False):
+    fan_block = {} if drop_fan else {
+        "fanControl": {
+            "value": {
+                "operationModes": {
+                    "auto": {
+                        "fanSpeed": {
+                            "currentMode": {"value": fan_current_mode_value, "values": ["auto", "fixed"]},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    return {
+        "id": "dev-1",
+        "deviceModel": "dx23",
+        "isCloudConnectionUp": {"value": True},
+        "managementPoints": [
+            {
+                "embeddedId": "climateControl",
+                "managementPointType": "climateControl",
+                "name": {"value": "Woonkamer"},
+                "operationMode": {"value": operation_mode_value},
+                **fan_block,
+            }
+        ],
+    }
+
+
+def test_read_value_top_level_and_nested():
+    device, _ = _make_device(operation_mode="auto", fan_current_mode="fixed")
+    assert device._read_value("climateControl", "operationMode", "") == "auto"
+    assert device._read_value("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") == "fixed"
+
+
+def test_read_value_returns_missing_for_unknown_paths():
+    device, _ = _make_device()
+    assert device._read_value("does-not-exist", "operationMode", "") is _MISSING
+    assert device._read_value("climateControl", "doesNotExist", "") is _MISSING
+    assert device._read_value("climateControl", "fanControl", "/operationModes/unknown/fanSpeed/currentMode") is _MISSING
+
+
+def test_read_value_distinguishes_missing_from_explicit_none():
+    device, _ = _make_device()
+    # Replace value with explicit None
+    device.daikin_data["managementPoints"][0]["operationMode"] = {"value": None}
+    assert device._read_value("climateControl", "operationMode", "") is None
+    # Drop the "value" key entirely -> missing
+    device.daikin_data["managementPoints"][0]["operationMode"] = {}
+    assert device._read_value("climateControl", "operationMode", "") is _MISSING
+
+
+@pytest.mark.asyncio
+async def test_successful_patch_records_pending_write():
+    device, _ = _make_device()
+    await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
+    assert ("climateControl", "operationMode", "") in device._pending_writes
+
+
+@pytest.mark.asyncio
+async def test_failed_patch_does_not_record_pending_write():
+    device, api = _make_device()
+    api.doBearerRequest = AsyncMock(return_value=False)
+    await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
+    assert device._pending_writes == {}
+
+
+@pytest.mark.asyncio
+async def test_matching_refresh_clears_pending_write_silently(caplog):
+    device, _ = _make_device()
+    await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
+        device.setJsonData(_new_payload("auto", fan_current_mode_value="auto"))
+    assert device._pending_writes == {}
+    assert "reverted" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mismatching_refresh_warns_and_drops_pending_write(caplog):
+    device, _ = _make_device()
+    await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
+    with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
+        device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
+    assert device._pending_writes == {}
+    assert "was set to 'auto'" in caplog.text
+    assert "now reports 'cooling'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_missing_characteristic_keeps_pending_write(caplog):
+    device, _ = _make_device()
+    await device.patch(
+        "dev-1", "climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode", "auto"
+    )
+    with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
+        device.setJsonData(_new_payload("auto", drop_fan=True))
+    # No fanControl in the new payload -> keep watching, no warning yet.
+    assert ("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") in device._pending_writes
+    assert "reverted" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_second_patch_supersedes_previous_pending_write(caplog):
+    device, _ = _make_device()
+    await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
+    await device.patch("dev-1", "climateControl", "operationMode", "", "cooling")
+    assert len(device._pending_writes) == 1
+    pending = next(iter(device._pending_writes.values()))
+    assert pending.value == "cooling"
+    # Cloud confirms the latest value -> no warning, no leftover entries.
+    with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
+        device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
+    assert device._pending_writes == {}
+    assert "reverted" not in caplog.text
+
+
+def test_expired_pending_write_is_dropped_silently(caplog):
+    device, _ = _make_device()
+    device._pending_writes[("climateControl", "operationMode", "")] = _PendingWrite(
+        embedded_id="climateControl",
+        data_point="operationMode",
+        data_point_path="",
+        value="auto",
+        set_at=datetime.now() - REVERT_CHECK_TTL - timedelta(seconds=1),
+    )
+    with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
+        device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
+    assert device._pending_writes == {}
+    assert "reverted" not in caplog.text

--- a/tests/test_device_pending_writes.py
+++ b/tests/test_device_pending_writes.py
@@ -77,32 +77,32 @@ def _new_payload(operation_mode_value, fan_current_mode_value=None, drop_fan=Fal
 
 def test_read_value_top_level_and_nested():
     device, _ = _make_device(operation_mode="auto", fan_current_mode="fixed")
-    assert device._read_value("climateControl", "operationMode", "") == "auto"
-    assert device._read_value("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") == "fixed"
+    assert device._read_value("climateControl", "operationMode", "") == "auto"  # nosec B101
+    assert device._read_value("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") == "fixed"  # nosec B101
 
 
 def test_read_value_returns_missing_for_unknown_paths():
     device, _ = _make_device()
-    assert device._read_value("does-not-exist", "operationMode", "") is _MISSING
-    assert device._read_value("climateControl", "doesNotExist", "") is _MISSING
-    assert device._read_value("climateControl", "fanControl", "/operationModes/unknown/fanSpeed/currentMode") is _MISSING
+    assert device._read_value("does-not-exist", "operationMode", "") is _MISSING  # nosec B101
+    assert device._read_value("climateControl", "doesNotExist", "") is _MISSING  # nosec B101
+    assert device._read_value("climateControl", "fanControl", "/operationModes/unknown/fanSpeed/currentMode") is _MISSING  # nosec B101
 
 
 def test_read_value_distinguishes_missing_from_explicit_none():
     device, _ = _make_device()
     # Replace value with explicit None
     device.daikin_data["managementPoints"][0]["operationMode"] = {"value": None}
-    assert device._read_value("climateControl", "operationMode", "") is None
+    assert device._read_value("climateControl", "operationMode", "") is None  # nosec B101
     # Drop the "value" key entirely -> missing
     device.daikin_data["managementPoints"][0]["operationMode"] = {}
-    assert device._read_value("climateControl", "operationMode", "") is _MISSING
+    assert device._read_value("climateControl", "operationMode", "") is _MISSING  # nosec B101
 
 
 @pytest.mark.asyncio
 async def test_successful_patch_records_pending_write():
     device, _ = _make_device()
     await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
-    assert ("climateControl", "operationMode", "") in device._pending_writes
+    assert ("climateControl", "operationMode", "") in device._pending_writes  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_failed_patch_does_not_record_pending_write():
     device, api = _make_device()
     api.doBearerRequest = AsyncMock(return_value=False)
     await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
-    assert device._pending_writes == {}
+    assert device._pending_writes == {}  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -120,8 +120,8 @@ async def test_matching_refresh_clears_pending_write_silently(caplog):
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("auto", fan_current_mode_value="auto"))
-    assert device._pending_writes == {}
-    assert "reverted" not in caplog.text
+    assert device._pending_writes == {}  # nosec B101
+    assert "reverted" not in caplog.text  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -130,9 +130,9 @@ async def test_mismatching_refresh_warns_and_drops_pending_write(caplog):
     await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
-    assert device._pending_writes == {}
-    assert "was set to 'auto'" in caplog.text
-    assert "now reports 'cooling'" in caplog.text
+    assert device._pending_writes == {}  # nosec B101
+    assert "was set to 'auto'" in caplog.text  # nosec B101
+    assert "now reports 'cooling'" in caplog.text  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -142,8 +142,8 @@ async def test_missing_characteristic_keeps_pending_write(caplog):
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("auto", drop_fan=True))
     # No fanControl in the new payload -> keep watching, no warning yet.
-    assert ("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") in device._pending_writes
-    assert "reverted" not in caplog.text
+    assert ("climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode") in device._pending_writes  # nosec B101
+    assert "reverted" not in caplog.text  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -151,14 +151,14 @@ async def test_second_patch_supersedes_previous_pending_write(caplog):
     device, _ = _make_device()
     await device.patch("dev-1", "climateControl", "operationMode", "", "auto")
     await device.patch("dev-1", "climateControl", "operationMode", "", "cooling")
-    assert len(device._pending_writes) == 1
+    assert len(device._pending_writes) == 1  # nosec B101
     pending = next(iter(device._pending_writes.values()))
-    assert pending.value == "cooling"
+    assert pending.value == "cooling"  # nosec B101
     # Cloud confirms the latest value -> no warning, no leftover entries.
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
-    assert device._pending_writes == {}
-    assert "reverted" not in caplog.text
+    assert device._pending_writes == {}  # nosec B101
+    assert "reverted" not in caplog.text  # nosec B101
 
 
 def test_expired_pending_write_is_dropped_silently(caplog):
@@ -172,5 +172,5 @@ def test_expired_pending_write_is_dropped_silently(caplog):
     )
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("cooling", fan_current_mode_value="auto"))
-    assert device._pending_writes == {}
-    assert "reverted" not in caplog.text
+    assert device._pending_writes == {}  # nosec B101
+    assert "reverted" not in caplog.text  # nosec B101

--- a/tests/test_device_pending_writes.py
+++ b/tests/test_device_pending_writes.py
@@ -1,5 +1,3 @@
-"""Unit tests for DaikinOnectaDevice silent-revert detection."""
-
 import logging
 from datetime import datetime
 from datetime import timedelta

--- a/tests/test_device_pending_writes.py
+++ b/tests/test_device_pending_writes.py
@@ -1,4 +1,5 @@
 """Unit tests for DaikinOnectaDevice silent-revert detection."""
+
 import logging
 from datetime import datetime
 from datetime import timedelta
@@ -43,19 +44,23 @@ def _make_device(operation_mode="auto", fan_current_mode="auto"):
 
 
 def _new_payload(operation_mode_value, fan_current_mode_value=None, drop_fan=False):
-    fan_block = {} if drop_fan else {
-        "fanControl": {
-            "value": {
-                "operationModes": {
-                    "auto": {
-                        "fanSpeed": {
-                            "currentMode": {"value": fan_current_mode_value, "values": ["auto", "fixed"]},
+    fan_block = (
+        {}
+        if drop_fan
+        else {
+            "fanControl": {
+                "value": {
+                    "operationModes": {
+                        "auto": {
+                            "fanSpeed": {
+                                "currentMode": {"value": fan_current_mode_value, "values": ["auto", "fixed"]},
+                            },
                         },
                     },
                 },
             },
-        },
-    }
+        }
+    )
     return {
         "id": "dev-1",
         "deviceModel": "dx23",
@@ -135,9 +140,7 @@ async def test_mismatching_refresh_warns_and_drops_pending_write(caplog):
 @pytest.mark.asyncio
 async def test_missing_characteristic_keeps_pending_write(caplog):
     device, _ = _make_device()
-    await device.patch(
-        "dev-1", "climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode", "auto"
-    )
+    await device.patch("dev-1", "climateControl", "fanControl", "/operationModes/auto/fanSpeed/currentMode", "auto")
     with caplog.at_level(logging.WARNING, logger="custom_components.daikin_onecta.device"):
         device.setJsonData(_new_payload("auto", drop_fan=True))
     # No fanControl in the new payload -> keep watching, no warning yet.


### PR DESCRIPTION
## Summary

Warn the user when a successful PATCH is silently reverted by the Daikin cloud, gateway or unit.

## Why

On some Sky Air installations with a wired master controller (BRC1H / Madoka) the cloud accepts an `operationMode` or `fanSpeed` PATCH with HTTP 204, but the indoor unit reverts to the previously active mode within a minute. Today the integration just renders the new value coming back from the cloud, which is indistinguishable from a legitimate external change and very hard to diagnose. See #684 and the [Daikin FAQ on synchronising BRC1H auto mode with Sky Air](https://www.daikin.eu/en_us/faq/how-can-i-synchronize-the-brc1h-auto-operation-mode-between-the-daikin-residential-controller-app-and-a-sky-air-unit.html).

## What changes

`DaikinOnectaDevice`:

- Track successful PATCH writes in `_pending_writes` (embedded id, data point, optional sub-path, expected value, timestamp).
- After every coordinator refresh (`setJsonData`), look up the actual value at the same characteristic path in the new payload and:
  - drop the entry silently if the value matches what we wrote,
  - emit a single `WARNING` with the expected/actual values and a hint about wired master controller / mode lock if it differs,
  - keep watching for up to 5 minutes when the value is not present yet,
  - then expire silently.

The PATCH request itself, return value and existing log lines are unchanged, so behaviour for working setups is identical apart from the absence of the new warning.

## Example log output on a silent revert

```
WARNING ... Device 'Woonkamer' value at climateControl/operationMode was set to 'auto' but
the Daikin cloud now reports 'cooling'. The unit, gateway or a wired master controller
(for example a BRC1H) most likely reverted the change. Check the master controller's
operation mode lock / cool-heat selection setting.
```

## Notes

- No new dependencies.
- Existing tests are unaffected; happy to add a unit test for `_check_pending_writes` and `_read_value` if you'd like — let me know which style fits best with the existing test setup.
- Refs #684.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of cases where a device update appears to “silently revert” after a successful change, by tracking recent updates and validating them against the next cloud refresh.
  * When refreshed data shows a mismatched value, the system now issues a warning and clears the stale pending update; confirmed matching updates are cleared automatically.
* **Tests**
  * Added unit tests for pending-write tracking, reading top-level and nested values, distinguishing missing fields from explicit nulls, superseding multiple updates, and timeout/expiry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->