### PR TITLE
Add release flow to add zip for download counts in HACS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,6 @@ jobs:
     - name: Create daikin_onecta.zip
       run: cd custom_components && zip -r ../daikin_onecta.zip daikin_onecta/
     - name: Upload daikin_onecta.zip to release
-      run: gh release upload ${{ github.event.release.tag_name }} daikin_onecta.zip
+      env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: gh release upload "$RELEASE_TAG" daikin_onecta.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Attach HACS Release Asset
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  attach-zip:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+    - name: Create daikin_onecta.zip
+      run: cd custom_components && zip -r ../daikin_onecta.zip daikin_onecta/
+    - name: Upload daikin_onecta.zip to release
+      uses: softprops/action-gh-release@v3
+      with:
+        files: daikin_onecta.zip
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,4 @@ jobs:
     - name: Create daikin_onecta.zip
       run: cd custom_components && zip -r ../daikin_onecta.zip daikin_onecta/
     - name: Upload daikin_onecta.zip to release
-      uses: softprops/action-gh-release@v3
-      with:
-        files: daikin_onecta.zip
-
+      run: gh release upload ${{ github.event.release.tag_name }} daikin_onecta.zip


### PR DESCRIPTION
    * .github/workflows/release.yml: Added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions workflow that packages the integration into a `daikin_onecta.zip` file and attaches it to each GitHub Release when it’s published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->