### PR TITLE
Only provide updater when the management point has a firmwareVersion …

### DIFF
--- a/custom_components/daikin_onecta/update.py
+++ b/custom_components/daikin_onecta/update.py
@@ -28,6 +28,14 @@ _LOGGER = logging.getLogger(__name__)
 # The Daikin Onecta cloud API exposes firmware updates
 
 
+def _get_value(mp: dict, characteristic: str) -> Any:
+    """Safely read .value from a management point characteristic."""
+    char = mp.get(characteristic)
+    if not isinstance(char, dict):
+        return None
+    return char.get("value")
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -44,12 +52,19 @@ async def async_setup_entry(
         "outdoorUnit",
         "indoorUnitHydro",
     }
+    required_version_fields = {
+        "firmwareVersion",
+        "softwareVersion",
+    }
 
     for device in onecta_data.devices.values():
         for mp_type in supported_management_point_types:
             management_point = _get_management_point(device, mp_type)
             if management_point is not None:
-                entities.append(DaikinFirmwareUpdateEntity(coordinator, device, management_point, mp_type))
+                for field in required_version_fields:
+                    if _get_value(management_point, field) is not None:
+                        entities.append(DaikinFirmwareUpdateEntity(coordinator, device, management_point, mp_type))
+                        break
 
     async_add_entities(entities)
 
@@ -60,14 +75,6 @@ def _get_management_point(device: DaikinOnectaDevice, mp_type: str) -> dict | No
         if mp.get("managementPointType") == mp_type:
             return mp
     return None
-
-
-def _get_value(mp: dict, characteristic: str) -> Any:
-    """Safely read .value from a management point characteristic."""
-    char = mp.get(characteristic)
-    if not isinstance(char, dict):
-        return None
-    return char.get("value")
 
 
 class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -297,7 +297,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -349,7 +349,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -401,7 +401,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -452,7 +452,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -504,7 +504,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -555,7 +555,7 @@
 # name: test_altherma3m[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -789,7 +789,7 @@
 # name: test_altherma3m[select.altherma_domestichotwatertank_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Schedule',
+      'friendly_name': 'Altherma DomesticHotWaterTank Schedule',
       'icon': 'mdi:calendar-clock',
       'options': list([
         'User defined',
@@ -1350,7 +1350,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -1401,7 +1401,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Heat up mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1458,7 +1458,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1517,7 +1517,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1576,7 +1576,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1635,7 +1635,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1688,7 +1688,7 @@
 # name: test_altherma3m[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -1745,7 +1745,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -2168,7 +2168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 46.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 50.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -13642,70 +13642,6 @@
     'state': 'off',
   })
 # ---
-# name: test_altherma[update.johnny_maaike_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '32db6075-b739-4026-b661-127009254b42_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma[update.johnny_maaike_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Johnny&Maaike OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_altherma[update.linde_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -13768,70 +13704,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_altherma[update.linde_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma[update.linde_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Linde OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_altherma[update.sanne_gateway_firmware_update-entry]
@@ -13898,70 +13770,6 @@
     'state': 'off',
   })
 # ---
-# name: test_altherma[update.sanne_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma[update.sanne_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Sanne OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_altherma[update.werkkamer_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -14024,70 +13832,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_altherma[update.werkkamer_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma[update.werkkamer_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Werkkamer OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_altherma[water_heater.altherma-entry]
@@ -16930,7 +16674,7 @@
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
+      'friendly_name': 'Altherma Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -16982,7 +16726,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
+      'friendly_name': 'Altherma Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17034,7 +16778,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
+      'friendly_name': 'Altherma Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17085,7 +16829,7 @@
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
+      'friendly_name': 'Altherma Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17137,7 +16881,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
+      'friendly_name': 'Altherma Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -17188,7 +16932,7 @@
 # name: test_altherma_ratelimit[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
+      'friendly_name': 'Altherma Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22252,7 +21996,7 @@
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
+      'friendly_name': 'Altherma Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -22309,7 +22053,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
+      'friendly_name': 'Altherma Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22368,7 +22112,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
+      'friendly_name': 'Altherma Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22427,7 +22171,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
+      'friendly_name': 'Altherma Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22486,7 +22230,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
+      'friendly_name': 'Altherma Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -22539,7 +22283,7 @@
 # name: test_altherma_ratelimit[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
+      'friendly_name': 'Altherma Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -22596,7 +22340,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
+      'friendly_name': 'Altherma Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -28083,70 +27827,6 @@
     'state': 'off',
   })
 # ---
-# name: test_altherma_ratelimit[update.johnny_maaike_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '32db6075-b739-4026-b661-127009254b42_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma_ratelimit[update.johnny_maaike_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Johnny&Maaike OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_altherma_ratelimit[update.linde_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -28209,70 +27889,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_altherma_ratelimit[update.linde_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma_ratelimit[update.linde_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Linde OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_altherma_ratelimit[update.sanne_gateway_firmware_update-entry]
@@ -28339,70 +27955,6 @@
     'state': 'off',
   })
 # ---
-# name: test_altherma_ratelimit[update.sanne_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma_ratelimit[update.sanne_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Sanne OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_altherma_ratelimit[update.werkkamer_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -28467,70 +28019,6 @@
     'state': 'off',
   })
 # ---
-# name: test_altherma_ratelimit[update.werkkamer_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_altherma_ratelimit[update.werkkamer_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Werkkamer OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_altherma_ratelimit[water_heater.altherma-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -28580,7 +28068,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 48.0,
-      'friendly_name': 'Altherma DomesticHotWaterTank',
+      'friendly_name': 'Altherma',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -28901,7 +28389,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_holiday_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is holiday mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is holiday mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -28953,7 +28441,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in emergency state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in emergency state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29005,7 +28493,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in error state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in error state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29056,7 +28544,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_in_installer_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is in installer state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in installer state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29108,7 +28596,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'friendly_name': 'Altherma Is in warning state',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is in warning state',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29159,7 +28647,7 @@
 # name: test_altherma_schedule[binary_sensor.altherma_domestichotwatertank_is_powerful_mode_active-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Is powerful mode active',
+      'friendly_name': 'Altherma DomesticHotWaterTank Is powerful mode active',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -29620,7 +29108,7 @@
 # name: test_altherma_schedule[select.altherma_domestichotwatertank_schedule-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Schedule',
+      'friendly_name': 'Altherma DomesticHotWaterTank Schedule',
       'icon': 'mdi:calendar-clock',
       'options': list([
         'User defined',
@@ -30476,7 +29964,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_error_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Error code',
+      'friendly_name': 'Altherma DomesticHotWaterTank Error code',
       'icon': 'mdi:information-outline',
     }),
     'context': <ANY>,
@@ -30527,7 +30015,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_heat_up_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Heat up mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heat up mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -30584,7 +30072,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating daily electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating daily electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -30643,7 +30131,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating monthly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating monthly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -30702,7 +30190,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating weekly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating weekly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -30761,7 +30249,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Altherma Heating yearly electrical consumption',
+      'friendly_name': 'Altherma DomesticHotWaterTank Heating yearly electrical consumption',
       'icon': 'mdi:fire',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -30814,7 +30302,7 @@
 # name: test_altherma_schedule[sensor.altherma_domestichotwatertank_setpoint_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Altherma Setpoint mode',
+      'friendly_name': 'Altherma DomesticHotWaterTank Setpoint mode',
       'icon': 'mdi:alphabetical',
     }),
     'context': <ANY>,
@@ -30871,7 +30359,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Altherma Tank temperature',
+      'friendly_name': 'Altherma DomesticHotWaterTank Tank temperature',
       'icon': 'mdi:bathtub-outline',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
@@ -31294,7 +30782,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 51.0,
-      'friendly_name': 'Altherma',
+      'friendly_name': 'Altherma DomesticHotWaterTank',
       'max_temp': 60.0,
       'min_temp': 30.0,
       'operation_list': list([
@@ -38220,70 +37708,6 @@
     'state': 'off',
   })
 # ---
-# name: test_button[update.bedroom_1_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.bedroom_1_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 1 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_button[update.bedroom_2_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -38346,70 +37770,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_button[update.bedroom_2_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.bedroom_2_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 2 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_button[update.bedroom_3_gateway_firmware_update-entry]
@@ -38476,70 +37836,6 @@
     'state': 'off',
   })
 # ---
-# name: test_button[update.bedroom_3_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.bedroom_3_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 3 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_button[update.kitchen_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -38602,70 +37898,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_button[update.kitchen_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.kitchen_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Kitchen OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_button[update.lounge_gateway_firmware_update-entry]
@@ -38732,70 +37964,6 @@
     'state': 'off',
   })
 # ---
-# name: test_button[update.lounge_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.lounge_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Lounge OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_button[update.master_bathroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -38860,70 +38028,6 @@
     'state': 'off',
   })
 # ---
-# name: test_button[update.master_bathroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.master_bathroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bathroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_button[update.master_bedroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -38986,70 +38090,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_button[update.master_bedroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_button[update.master_bedroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bedroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_climate[binary_sensor.altherma_climatecontrol_is_holiday_mode_active-entry]
@@ -50503,70 +49543,6 @@
     'state': 'off',
   })
 # ---
-# name: test_climate[update.johnny_maaike_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '32db6075-b739-4026-b661-127009254b42_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate[update.johnny_maaike_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Johnny&Maaike OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_climate[update.linde_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -50629,70 +49605,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_climate[update.linde_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c04342c4-2fbc-4a32-b54d-6067fa1311f6_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate[update.linde_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Linde OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.linde_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_climate[update.sanne_gateway_firmware_update-entry]
@@ -50759,70 +49671,6 @@
     'state': 'off',
   })
 # ---
-# name: test_climate[update.sanne_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'f7ff41ad-4169-45e5-8df4-15e033a05668_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate[update.sanne_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Sanne OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.sanne_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_climate[update.werkkamer_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -50885,70 +49733,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_climate[update.werkkamer_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate[update.werkkamer_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Werkkamer OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_climate[water_heater.altherma-entry]
@@ -52687,70 +51471,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_climate_fixedfanmode[update.werkkamer_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate_fixedfanmode[update.werkkamer_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Werkkamer OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_climate_floorheatingairflow[binary_sensor.laurens_climatecontrol_is_cool_heat_master-entry]
@@ -57162,70 +55882,6 @@
     'state': 'off',
   })
 # ---
-# name: test_climate_floorheatingairflow[update.laurens_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.laurens_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '71f33ee1-a82d-4f08-8f61-bf25fd872731_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate_floorheatingairflow[update.laurens_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Laurens OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.laurens_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_climate_floorheatingairflow[update.woonkamer_airco_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -57288,70 +55944,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_climate_floorheatingairflow[update.woonkamer_airco_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.woonkamer_airco_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '27920256-e0af-4780-8f5f-1f88d8fdf0ba_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate_floorheatingairflow[update.woonkamer_airco_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Woonkamer airco OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.woonkamer_airco_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_climate_homekit_fan_mode_aliases[binary_sensor.werkkamer_climatecontrol_is_holiday_mode_active-entry]
@@ -59026,70 +57618,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_climate_homekit_fan_mode_aliases[update.werkkamer_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '6f944461-08cb-4fee-979c-710ff66cea77_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_climate_homekit_fan_mode_aliases[update.werkkamer_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Werkkamer OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.werkkamer_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry2[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
@@ -65995,70 +64523,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry2[update.bedroom_1_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.bedroom_1_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 1 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry2[update.bedroom_2_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -66121,70 +64585,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry2[update.bedroom_2_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.bedroom_2_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 2 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry2[update.bedroom_3_gateway_firmware_update-entry]
@@ -66251,70 +64651,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry2[update.bedroom_3_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.bedroom_3_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 3 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry2[update.kitchen_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -66377,70 +64713,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry2[update.kitchen_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.kitchen_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Kitchen OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry2[update.lounge_gateway_firmware_update-entry]
@@ -66507,70 +64779,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry2[update.lounge_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.lounge_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Lounge OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry2[update.master_bathroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -66635,70 +64843,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry2[update.master_bathroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.master_bathroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bathroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry2[update.master_bedroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -66761,70 +64905,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry2[update.master_bedroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry2[update.master_bedroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bedroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry[binary_sensor.bedroom_1_climatecontrol_is_holiday_mode_active-entry]
@@ -73730,70 +71810,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry[update.bedroom_1_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '7bd36d96-73b3-44a1-8642-f3650e9cc732_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.bedroom_1_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 1 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_1_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry[update.bedroom_2_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -73856,70 +71872,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry[update.bedroom_2_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'df4648e9-d40b-4242-b9fe-e5d0f6451a6b_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.bedroom_2_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 2 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_2_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry[update.bedroom_3_gateway_firmware_update-entry]
@@ -73986,70 +71938,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry[update.bedroom_3_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '4c60a395-f659-47d6-9a4b-be9aae836761_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.bedroom_3_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Bedroom 3 OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.bedroom_3_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry[update.kitchen_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -74112,70 +72000,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry[update.kitchen_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '72b407b4-4e6f-47e2-814f-ee36d1548858_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.kitchen_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Kitchen OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.kitchen_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dry[update.lounge_gateway_firmware_update-entry]
@@ -74242,70 +72066,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry[update.lounge_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1bcc6300-47e8-46c8-9ca8-79b4e649e145_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.lounge_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Lounge OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.lounge_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry[update.master_bathroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -74370,70 +72130,6 @@
     'state': 'off',
   })
 # ---
-# name: test_dry[update.master_bathroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1b4e05a4-466d-41d8-b90e-19dded548684_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.master_bathroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bathroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bathroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_dry[update.master_bedroom_gateway_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -74496,70 +72192,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_dry[update.master_bedroom_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'c7d4957f-2b0a-468f-adbc-06d150d9af39_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dry[update.master_bedroom_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Master Bedroom OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.master_bedroom_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_dx4_firmwareupdate[binary_sensor.johnny_maaike_climatecontrol_is_holiday_mode_active-entry]
@@ -76381,70 +74013,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
-  })
-# ---
-# name: test_dx4_firmwareupdate[update.johnny_maaike_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '32db6075-b739-4026-b661-127009254b42_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_dx4_firmwareupdate[update.johnny_maaike_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Johnny&Maaike OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.johnny_maaike_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_fanmode[binary_sensor.sala_climatecontrol_is_holiday_mode_active-entry]
@@ -79786,70 +77354,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_gas[update.my_living_room_userinterface_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.my_living_room_userinterface_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '7edb544e-2c53-405b-98bc-3d9392f4d1f9_userInterface_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_gas[update.my_living_room_userinterface_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'My Living Room UserInterface Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.my_living_room_userinterface_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_gas[water_heater.my_living_room-entry]
@@ -86907,134 +84411,6 @@
     'state': '0',
   })
 # ---
-# name: test_minimal_data[update.altherma_gateway_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.altherma_gateway_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'b84e8af3-310a-4e6e-8e52-295573423485_gateway_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_minimal_data[update.altherma_gateway_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Altherma Gateway Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.altherma_gateway_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_minimal_data[update.altherma_indoorunithydro_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.altherma_indoorunithydro_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': 'b84e8af3-310a-4e6e-8e52-295573423485_indoorUnitHydro_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_minimal_data[update.altherma_indoorunithydro_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Altherma IndoorUnitHydro Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.altherma_indoorunithydro_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_minimal_data[update.altherma_userinterface_firmware_update-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -88918,70 +86294,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
-  })
-# ---
-# name: test_offlinedevice[update.studio_outdoorunit_firmware_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'update',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'update.studio_outdoorunit_firmware_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Firmware update',
-    'options': dict({
-    }),
-    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
-    'original_icon': 'mdi:update',
-    'original_name': 'Firmware update',
-    'platform': 'daikin_onecta',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <UpdateEntityFeature: 1>,
-    'translation_key': 'firmwareupdate',
-    'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_outdoorUnit_firmware_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_offlinedevice[update.studio_outdoorunit_firmware_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'auto_update': False,
-      'device_class': 'firmware',
-      'display_precision': 0,
-      'entity_picture': '/api/brands/integration/daikin_onecta/icon.png',
-      'friendly_name': 'Studio OutdoorUnit Firmware update',
-      'icon': 'mdi:update',
-      'in_progress': False,
-      'installed_version': None,
-      'latest_version': None,
-      'release_summary': None,
-      'release_url': None,
-      'skipped_version': None,
-      'supported_features': <UpdateEntityFeature: 1>,
-      'title': None,
-      'update_percentage': None,
-    }),
-    'context': <ANY>,
-    'entity_id': 'update.studio_outdoorunit_firmware_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
   })
 # ---
 # name: test_schedule[binary_sensor.master_climatecontrol_is_holiday_mode_active-entry]


### PR DESCRIPTION
…or softwareVersion

    * custom_components/daikin_onecta/update.py:
    * tests/snapshots/test_init.ambr:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware update entries are now only shown when version information is available.
  * Improved handling of missing or unexpected device data to avoid setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->