### PR TITLE
Include managementPointSubType in entity names

### DIFF
--- a/custom_components/daikin_onecta/binary_sensor.py
+++ b/custom_components/daikin_onecta/binary_sensor.py
@@ -81,7 +81,7 @@ class DaikinBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self._device = device
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(embedded_id, management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -37,6 +37,26 @@ class DaikinOnectaDevice:
             result = icu["value"]
         return result
 
+    def device_name_suffix(self, embedded_id: str, management_point_type: str) -> str:
+        """Return the user-visible suffix for a management-point sub-device.
+
+        Includes ``managementPointSubType`` (e.g. ``mainZone``) when present,
+        so multi-zone setups can distinguish their sub-devices in HA. The
+        management point is identified by its ``embeddedId`` so that payloads
+        with multiple management points of the same type but different
+        sub-types resolve correctly. The device-registry identifier
+        (``id + management_point_type``) is left unchanged so existing
+        installations keep their entities.
+        """
+        mpt = management_point_type[0].upper() + management_point_type[1:]
+        for mp in self.daikin_data.get("managementPoints", []):
+            if mp.get("embeddedId") == embedded_id:
+                subtype = mp.get("managementPointSubType")
+                if isinstance(subtype, str) and subtype:
+                    mpt += " " + subtype[0].upper() + subtype[1:]
+                break
+        return mpt
+
     def fill_device_info(self, device_info, management_point_type):
         manufacturer = {"manufacturer": "Daikin"}
         device_info.update(**manufacturer)

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -50,7 +50,7 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
         super().__init__(coordinator)
         self._device = device
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(embedded_id, management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,

--- a/custom_components/daikin_onecta/sensor.py
+++ b/custom_components/daikin_onecta/sensor.py
@@ -179,7 +179,7 @@ class DaikinEnergySensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._device = device
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(embedded_id, management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
@@ -278,7 +278,7 @@ class DaikinValueSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._device = device
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(embedded_id, management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,

--- a/custom_components/daikin_onecta/switch.py
+++ b/custom_components/daikin_onecta/switch.py
@@ -103,7 +103,7 @@ class DaikinSwitch(CoordinatorEntity, ToggleEntity):
             self._attr_entity_category = sensor_settings[ENTITY_CATEGORY]
             self._attr_translation_key = sensor_settings[TRANSLATION_KEY]
         self._attr_unique_id = f"{self._device.id}_{self._management_point_type}_{self._value}"
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(embedded_id, management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,

--- a/custom_components/daikin_onecta/update.py
+++ b/custom_components/daikin_onecta/update.py
@@ -25,7 +25,9 @@ from .device import DaikinOnectaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-# The Daikin Onecta cloud API exposes firmware updates
+# The Daikin Onecta cloud API exposes firmware/software version information
+# on multiple management point types: ``gateway`` (firmware update),
+# ``userInterface``, ``outdoorUnit`` and ``indoorUnitHydro``.
 
 
 def _get_value(mp: dict, characteristic: str) -> Any:
@@ -92,7 +94,7 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
         self._device = device
         self._coordinator = coordinator
         self._management_point_type = management_point_type
-        mpt = management_point_type[0].upper() + management_point_type[1:]
+        mpt = self._device.device_name_suffix(gateway_mp.get("embeddedId"), management_point_type)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -242,7 +242,7 @@ async def test_schedule(
     """Test entities."""
     await snapshot_platform_entities(hass, aioclient_mock, config_entry, Platform.SENSOR, entity_registry, snapshot, "schedule")
 
-    assert hass.states.get("select.master_climatecontrol_schedule").state == "off"
+    assert hass.states.get("select.master_climatecontrol_mainzone_schedule").state == "off"
 
 
 @pytest.mark.asyncio
@@ -883,9 +883,9 @@ async def test_climate(
     await snapshot_platform_entities(hass, aioclient_mock, config_entry, Platform.SENSOR, entity_registry, snapshot, "altherma")
 
     assert hass.states.get("climate.werkkamer_room_temperature").state == HVACMode.OFF
-    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_is_cool_heat_master").state == STATE_ON
-    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_is_in_caution_state").state == STATE_OFF
-    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_is_in_warning_state").state == STATE_OFF
+    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_mainzone_is_cool_heat_master").state == STATE_ON
+    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_mainzone_is_in_caution_state").state == STATE_OFF
+    assert hass.states.get("binary_sensor.werkkamer_climatecontrol_mainzone_is_in_warning_state").state == STATE_OFF
 
     with patch(
         "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
@@ -1205,26 +1205,26 @@ async def test_climate(
         assert hass.states.get("climate.werkkamer_room_temperature").state == HVACMode.COOL
 
         # Test streamer mode switch
-        assert hass.states.get("switch.werkkamer_climatecontrol_streamer_mode").state == STATE_OFF
+        assert hass.states.get("switch.werkkamer_climatecontrol_mainzone_streamer_mode").state == STATE_OFF
 
         # Set the streamer mode on
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_streamer_mode"},
+            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_mainzone_streamer_mode"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 22
         assert aioclient_mock.mock_calls[21][2] == '{"value": "on"}'
-        assert hass.states.get("switch.werkkamer_climatecontrol_streamer_mode").state == STATE_ON
+        assert hass.states.get("switch.werkkamer_climatecontrol_mainzone_streamer_mode").state == STATE_ON
 
         # Set the streamer mode on a second time shouldn't result in a call to daikin
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_streamer_mode"},
+            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_mainzone_streamer_mode"},
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -1235,20 +1235,20 @@ async def test_climate(
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_streamer_mode"},
+            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_mainzone_streamer_mode"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 23
         assert aioclient_mock.mock_calls[22][2] == '{"value": "off"}'
-        assert hass.states.get("switch.werkkamer_climatecontrol_streamer_mode").state == STATE_OFF
+        assert hass.states.get("switch.werkkamer_climatecontrol_mainzone_streamer_mode").state == STATE_OFF
 
         # Set the streamer mode off a second time shouldn't result in a call to daikin
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_streamer_mode"},
+            {ATTR_ENTITY_ID: "switch.werkkamer_climatecontrol_mainzone_streamer_mode"},
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -1292,27 +1292,27 @@ async def test_climate(
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: "select.werkkamer_climatecontrol_schedule", ATTR_OPTION: "0"},
+            {ATTR_ENTITY_ID: "select.werkkamer_climatecontrol_mainzone_schedule", ATTR_OPTION: "0"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 27
         assert aioclient_mock.mock_calls[26][2] == '{"scheduleId": "0", "enabled": true}'
-        assert hass.states.get("select.werkkamer_climatecontrol_schedule").state == "0"
+        assert hass.states.get("select.werkkamer_climatecontrol_mainzone_schedule").state == "0"
 
         # Set the device with no schedule
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: "select.werkkamer_climatecontrol_schedule", ATTR_OPTION: SCHEDULE_OFF},
+            {ATTR_ENTITY_ID: "select.werkkamer_climatecontrol_mainzone_schedule", ATTR_OPTION: SCHEDULE_OFF},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 28
         assert aioclient_mock.mock_calls[27][2] == '{"scheduleId": "0", "enabled": false}'
-        assert hass.states.get("select.werkkamer_climatecontrol_schedule").state == SCHEDULE_OFF
+        assert hass.states.get("select.werkkamer_climatecontrol_mainzone_schedule").state == SCHEDULE_OFF
 
         aioclient_mock.put(
             DAIKIN_API_URL
@@ -1324,27 +1324,27 @@ async def test_climate(
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_schedule", ATTR_OPTION: "User defined"},
+            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_mainzone_schedule", ATTR_OPTION: "User defined"},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 29
         assert aioclient_mock.mock_calls[28][2] == '{"scheduleId": "scheduleCoolingRT1", "enabled": true}'
-        assert hass.states.get("select.altherma_climatecontrol_schedule").state == "User defined"
+        assert hass.states.get("select.altherma_climatecontrol_mainzone_schedule").state == "User defined"
 
         # Set the device with no schedule
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_schedule", ATTR_OPTION: SCHEDULE_OFF},
+            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_mainzone_schedule", ATTR_OPTION: SCHEDULE_OFF},
             blocking=True,
         )
         await hass.async_block_till_done()
 
         assert len(aioclient_mock.mock_calls) == 30
         assert aioclient_mock.mock_calls[29][2] == '{"scheduleId": "scheduleCoolingRT1", "enabled": false}'
-        assert hass.states.get("select.altherma_climatecontrol_schedule").state == SCHEDULE_OFF
+        assert hass.states.get("select.altherma_climatecontrol_mainzone_schedule").state == SCHEDULE_OFF
 
         # Turn off the device through the hvac mode
         await hass.services.async_call(
@@ -1429,7 +1429,7 @@ async def test_climate(
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_schedule", ATTR_OPTION: "User defined"},
+            {ATTR_ENTITY_ID: "select.altherma_climatecontrol_mainzone_schedule", ATTR_OPTION: "User defined"},
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -1441,7 +1441,7 @@ async def test_climate(
 
         assert len(aioclient_mock.mock_calls) == 1
         assert aioclient_mock.mock_calls[0][2] == '{"scheduleId": "scheduleCoolingRT1", "enabled": true}'
-        assert hass.states.get("select.altherma_climatecontrol_schedule").state == SCHEDULE_OFF
+        assert hass.states.get("select.altherma_climatecontrol_mainzone_schedule").state == SCHEDULE_OFF
 
         aioclient_mock.clear_requests()
         aioclient_mock.patch(


### PR DESCRIPTION
Part of #687.

Includes the `managementPointSubType` in the generated entity names so that, on multi-zone or multi-management-point systems, the entities get distinguishable names (for example `... Main Zone`) instead of colliding on the generic management point type.

## Changes
- Add `DaikinOnectaDevice.device_name_suffix(embedded_id, management_point_type)` which appends the `managementPointSubType` (when present) to the suffix.
- Use it across `binary_sensor`, `select`, `sensor`, `switch` and `update` entities.
- The device-registry identifiers are left unchanged, so existing installations keep their entities and only the display name is affected.
- Update `tests/test_init.py` entity-id expectations accordingly.

This is the first focused part split out of #688. The silent-revert detection that previously also lived in that branch has been dropped (see #685).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity naming so climate, sensor, switch, schedule, and update entries display more consistent, readable names.
  * Updated several entities to include the correct zone or management-point label, reducing confusing or duplicated names in the UI.
  * Firmware update entries now show more accurate device naming across supported unit types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->