### PR TITLE
Don't check for valid token before calling into oauth2 and added some logging

### DIFF
--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -3,7 +3,6 @@ import asyncio
 import json
 import logging
 from datetime import datetime
-from http import HTTPStatus
 
 from aiohttp import ClientResponseError
 from homeassistant import config_entries

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -62,9 +62,10 @@ class DaikinApi:
             await self.session.async_ensure_token_valid()
         except ClientResponseError as ex:
             # https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials
+            _LOGGER.exception("Refreshing token failed")
             if ex.status == HTTPStatus.BAD_REQUEST:
                 raise ConfigEntryAuthFailed(f"Problem refreshing token: {ex}") from ex
-            raise ex
+            raise
 
         return self.session.token["access_token"]
 

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -58,15 +58,13 @@ class DaikinApi:
         _LOGGER.info("Daikin Onecta API initialized.")
 
     async def async_get_access_token(self) -> str:
-        """Return a valid access token."""
-        if not self.session.valid_token:
-            try:
-                await self.session.async_ensure_token_valid()
-            except ClientResponseError as ex:
-                # https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials
-                if ex.status == HTTPStatus.BAD_REQUEST:
-                    raise ConfigEntryAuthFailed(f"Problem refreshing token: {ex}") from ex
-                raise ex
+        try:
+            await self.session.async_ensure_token_valid()
+        except ClientResponseError as ex:
+            # https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials
+            if ex.status == HTTPStatus.BAD_REQUEST:
+                raise ConfigEntryAuthFailed(f"Problem refreshing token: {ex}") from ex
+            raise ex
 
         return self.session.token["access_token"]
 

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -63,7 +63,7 @@ class DaikinApi:
         except ClientResponseError as ex:
             # https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials
             _LOGGER.exception("Refreshing token failed")
-            if ex.status == HTTPStatus.BAD_REQUEST:
+            if 400 <= ex.status < 500:
                 raise ConfigEntryAuthFailed(f"Problem refreshing token: {ex}") from ex
             raise
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Daikin Onecta authentication by consistently validating/refreshing access tokens before API requests.
  * Enhanced error handling so client-side API failures (4xx) are now reported as authentication/credentials issues for clearer recovery.
  * Other response errors are still surfaced as before to support straightforward troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->