### PR TITLE
More token cleanup

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -2,11 +2,13 @@
 import logging
 
 import jwt
-from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import OAuth2TokenRequestError
+from homeassistant.exceptions import OAuth2TokenRequestReauthError
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .coordinator import OnectaDataUpdateCoordinator
@@ -40,7 +42,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     try:
         await daikin_api.async_get_access_token()
-    except ClientError as err:
+    except OAuth2TokenRequestReauthError as err:
+        raise ConfigEntryAuthFailed from err
+    except (OAuth2TokenRequestError, aiohttp.ClientError) as err:
         raise ConfigEntryNotReady from err
 
     config_entry.runtime_data = OnectaRuntimeData(coordinator=None, daikin_api=daikin_api, devices={})

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -1,6 +1,7 @@
 """Platform for the Daikin AC."""
 import logging
 
+import aiohttp
 import jwt
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -4,10 +4,8 @@ import json
 import logging
 from datetime import datetime
 
-from aiohttp import ClientResponseError
 from homeassistant import config_entries
 from homeassistant import core
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -57,15 +55,7 @@ class DaikinApi:
         _LOGGER.info("Daikin Onecta API initialized.")
 
     async def async_get_access_token(self) -> str:
-        try:
-            await self.session.async_ensure_token_valid()
-        except ClientResponseError as ex:
-            # https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials
-            _LOGGER.exception("Refreshing token failed")
-            if 400 <= ex.status < 500:
-                raise ConfigEntryAuthFailed(f"Problem refreshing token: {ex}") from ex
-            raise
-
+        await self.session.async_ensure_token_valid()
         return self.session.token["access_token"]
 
     async def doBearerRequest(self, method, resource_url, options=None):


### PR DESCRIPTION
    * custom_components/daikin_onecta/__init__.py:
    * custom_components/daikin_onecta/daikin_api.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in error handling when connecting to Daikin Onecta.
  * Authentication failures now clearly prompt reauthorization, while temporary connection or service issues are treated as setup-unavailable conditions and can be retried.
  * Token refresh errors are handled consistently, improving reliability during account setup and reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->