### PR TITLE
Fix OAuth2 token error handling for HA 2026.3

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -11,7 +11,9 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.exceptions import OAuth2TokenRequestError
 from homeassistant.exceptions import OAuth2TokenRequestReauthError
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.config_entry_oauth2_flow import ImplementationUnavailableError
 
+from .const import DOMAIN
 from .coordinator import OnectaDataUpdateCoordinator
 from .coordinator import OnectaRuntimeData
 from .daikin_api import DaikinApi
@@ -37,7 +39,13 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Establish connection with Daikin."""
-    implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(hass, config_entry)
+    try:
+        implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(hass, config_entry)
+    except ImplementationUnavailableError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="oauth2_implementation_unavailable",
+        ) from err
 
     daikin_api = DaikinApi(hass, config_entry, implementation)
 
@@ -51,10 +59,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     config_entry.runtime_data = OnectaRuntimeData(coordinator=None, daikin_api=daikin_api, devices={})
     config_entry.runtime_data.coordinator = OnectaDataUpdateCoordinator(hass, config_entry)
 
-    try:
-        await config_entry.runtime_data.coordinator.async_config_entry_first_refresh()
-    except Exception as ex:
-        raise ConfigEntryNotReady(f"Config Not Ready: {ex}")
+    # Let the coordinator raise ConfigEntryAuthFailed / ConfigEntryNotReady directly.
+    # Do not wrap first_refresh in a broad Exception handler: that would convert
+    # reauth failures into ConfigEntryNotReady and skip the reauth flow.
+    await config_entry.runtime_data.coordinator.async_config_entry_first_refresh()
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 

--- a/custom_components/daikin_onecta/strings.json
+++ b/custom_components/daikin_onecta/strings.json
@@ -14,6 +14,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
@@ -21,12 +22,21 @@
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Invalid or expired token; please reconfigure the integration.",
+      "wrong_account": "Please ensure you reconfigure against the same account.",
+      "unknown": "Failed due to an unexpected error."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
+  "exceptions": {
+    "oauth2_implementation_unavailable": {
+      "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    }
+  },
+
   "options": {
     "step": {
       "init": {

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -22,7 +22,8 @@
       "init_failed": "Failed to initialize Daikin API.",
       "invalid_token": "Invalid or expired token; please reconfigure the integration.",
       "unknown": "Failed due to an unexpected error.",
-      "wrong_account": "Please ensure you reconfigure against the same account."
+      "wrong_account": "Please ensure you reconfigure against the same account.",
+      "oauth_implementation_unavailable": "OAuth2 implementation is currently unavailable"
     },
     "error": {
       "cannot_connect": "Failed to connect",
@@ -301,6 +302,11 @@
       "retry_after": "Retry after",
       "ratelimit_reset": "Rate limit reset",
       "oauth2_token_valid": "OAuth2 token valid"
+    }
+  },
+  "exceptions": {
+    "oauth2_implementation_unavailable": {
+      "message": "OAuth2 implementation is currently unavailable"
     }
   }
 }

--- a/tests/test_oauth_setup.py
+++ b/tests/test_oauth_setup.py
@@ -1,0 +1,134 @@
+"""Tests for OAuth2 setup error handling (HA 2026.3+)."""
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from aiohttp import RequestInfo
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import OAuth2TokenRequestError
+from homeassistant.exceptions import OAuth2TokenRequestReauthError
+from homeassistant.helpers.config_entry_oauth2_flow import ImplementationUnavailableError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from yarl import URL
+
+from custom_components.daikin_onecta import async_setup_entry
+from custom_components.daikin_onecta.const import DOMAIN
+from custom_components.daikin_onecta.coordinator import OnectaDataUpdateCoordinator
+
+
+def _token_request_info() -> RequestInfo:
+    url = URL("https://idp.onecta.daikineurope.com/v1/oidc/token")
+    return RequestInfo(url=url, method="POST", headers={}, real_url=url)
+
+
+def _reauth_error() -> OAuth2TokenRequestReauthError:
+    return OAuth2TokenRequestReauthError(
+        domain=DOMAIN,
+        request_info=_token_request_info(),
+        status=401,
+        message="invalid_grant",
+    )
+
+
+def _token_error() -> OAuth2TokenRequestError:
+    return OAuth2TokenRequestError(
+        domain=DOMAIN,
+        request_info=_token_request_info(),
+        status=500,
+        message="server error",
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_reauth_on_token_request(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Token reauth errors during ensure must raise ConfigEntryAuthFailed."""
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
+            side_effect=_reauth_error(),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_not_ready_on_transient_token_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Recoverable OAuth token errors must raise ConfigEntryNotReady."""
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
+            side_effect=_token_error(),
+        ),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_not_ready_when_implementation_unavailable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Missing OAuth implementation must raise ConfigEntryNotReady."""
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            side_effect=ImplementationUnavailableError("no impl"),
+        ),
+        pytest.raises(ConfigEntryNotReady) as exc_info,
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    if exc_info.value.translation_domain != DOMAIN:
+        pytest.fail(f"unexpected translation_domain: {exc_info.value.translation_domain}")
+    if exc_info.value.translation_key != "oauth2_implementation_unavailable":
+        pytest.fail(f"unexpected translation_key: {exc_info.value.translation_key}")
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_preserves_reauth_from_first_refresh(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """First refresh reauth must not be converted into ConfigEntryNotReady."""
+    # A broad Exception handler around async_config_entry_first_refresh would
+    # swallow ConfigEntryAuthFailed and prevent the reauth UI from starting.
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.daikin_onecta.DaikinApi.async_get_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+        patch.object(
+            OnectaDataUpdateCoordinator,
+            "async_config_entry_first_refresh",
+            side_effect=ConfigEntryAuthFailed("token expired"),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    if config_entry.state is ConfigEntryState.LOADED:
+        pytest.fail("config entry should not be LOADED after reauth failure")


### PR DESCRIPTION
Fixes https://github.com/jwillemsen/daikin_onecta/issues/630

Home Assistant 2026.3 changed how the OAuth2 helper reports token request failures. Setup already mapped the new exceptions in most places, but first refresh was still wrapped in a broad `except Exception` that turned `ConfigEntryAuthFailed` into `ConfigEntryNotReady`. That meant reauth never kicked in when the token failed during the initial refresh.

## Changes
- Let `async_config_entry_first_refresh()` raise auth/not-ready errors as-is instead of converting everything to `ConfigEntryNotReady`
- Handle `ImplementationUnavailableError` when the OAuth implementation is missing
- Add unit tests for reauth, transient token errors, missing implementation, and the first-refresh reauth path

Tested locally with HA 2026.7.2: 39/39 passed (including 4 new setup tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OAuth2 setup failures in the Daikin Onecta integration, including unavailable OAuth2 implementations and temporary token issues.
  * Preserved authentication/reauthentication failures so they trigger the correct reauth flow instead of being treated as temporary unavailability.
  * Added clearer, localized OAuth2-related abort and exception messages.

* **Tests**
  * Added new pytest coverage for OAuth2 setup error handling and initial refresh behavior, ensuring auth failures aren’t swallowed and unavailable implementations surface with the expected error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->