### PR TITLE
Fix setup translations for the OAuth2 config flow

### DIFF
--- a/custom_components/daikin_onecta/strings.json
+++ b/custom_components/daikin_onecta/strings.json
@@ -2,6 +2,12 @@
   "config": {
     "step": {
       "pick_implementation": {
+        "data": {
+          "implementation": "[%key:common::config_flow::data::implementation%]"
+        },
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       },
       "reauth_confirm": {
@@ -14,6 +20,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
@@ -21,7 +28,10 @@
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Invalid or expired token; please reconfigure the integration.",
+      "wrong_account": "Please ensure you reconfigure against the same account.",
+      "unknown": "Failed due to an unexpected error."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/custom_components/daikin_onecta/translations/bg.json
+++ b/custom_components/daikin_onecta/translations/bg.json
@@ -15,28 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Интеграцията вече е конфигурирана.",
-      "cannot_connect": "Неуспешно свързване с Daikin Cloud.",
-      "init_failed": "Неуспешна инициализация на Daikin API."
-    },
-    "error": {
-      "cannot_connect": "Неуспешно свързване",
-      "device_fail": "Неочаквана грешка",
-      "device_timeout": "Неуспешно свързване",
-      "forbidden": "Невалидно удостоверяване",
-      "invalid_auth": "Невалидно удостоверяване",
-      "unknown": "Неочаквана грешка"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "Email адрес",
-          "password": "Парола"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Въведете email адреса и паролата, които използвате за вход в Daikin Cloud, след което натиснете „Изпрати“.",
-        "title": "Конфигуриране на Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Интеграцията Daikin Onecta трябва да удостовери акаунта ви отново"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Невалиден или изтекъл токен; моля, преконфигурирайте интеграцията.",
+      "wrong_account": "Уверете се, че преконфигурирате същия акаунт.",
+      "unknown": "Неуспешно поради неочаквана грешка."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/de.json
+++ b/custom_components/daikin_onecta/translations/de.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Die Integration ist bereits konfiguriert.",
-      "cannot_connect": "Verbindung zur Daikin Cloud konnte nicht hergestellt werden.",
-      "init_failed": "Daikin API konnte nicht initialisiert werden.",
-      "wrong_account": "Bitte stellen Sie sicher, dass Sie die Konfiguration für dasselbe Konto neu vornehmen."
-    },
-    "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen",
-      "device_fail": "Unerwarteter Fehler",
-      "device_timeout": "Verbindung fehlgeschlagen",
-      "forbidden": "Ungültige Authentifizierung",
-      "invalid_auth": "Ungültige Authentifizierung",
-      "unknown": "Unerwarteter Fehler"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-Mail Adresse",
-          "password": "Passwort"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Geben Sie die E-Mail-Adresse und das Passwort ein, die Sie für die Anmeldung bei Daikin Cloud verwenden, und drücken Sie dann auf Senden.",
-        "title": "Daikin Onecta konfigurieren"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Die Daikin Onecta Integration muss Ihr Konto erneut authentifizieren"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ungültiges oder abgelaufenes Token; bitte die Integration neu konfigurieren.",
+      "wrong_account": "Bitte stellen Sie sicher, dass Sie dasselbe Konto neu konfigurieren.",
+      "unknown": "Fehlgeschlagen aufgrund eines unerwarteten Fehlers."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/el.json
+++ b/custom_components/daikin_onecta/translations/el.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Η ενσωμάτωση έχει ήδη ρυθμιστεί.",
-      "cannot_connect": "Αποτυχία σύνδεσης με το Daikin Cloud.",
-      "init_failed": "Αποτυχία αρχικοποίησης του Daikin API.",
-      "wrong_account": "Βεβαιωθείτε ότι επαναρυθμίζετε με τον ίδιο λογαριασμό."
-    },
-    "error": {
-      "cannot_connect": "Αποτυχία σύνδεσης",
-      "device_fail": "Μη αναμενόμενο σφάλμα",
-      "device_timeout": "Αποτυχία σύνδεσης",
-      "forbidden": "Μη έγκυρος έλεγχος ταυτότητας",
-      "invalid_auth": "Μη έγκυρος έλεγχος ταυτότητας",
-      "unknown": "Μη αναμενόμενο σφάλμα"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "Διεύθυνση email",
-          "password": "Κωδικός πρόσβασης"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Εισαγάγετε τη διεύθυνση email και τον κωδικό πρόσβασης που χρησιμοποιείτε για τη σύνδεση στο Daikin Cloud και πατήστε Υποβολή.",
-        "title": "Ρύθμιση Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Η ενσωμάτωση Daikin Onecta πρέπει να επαναπιστοποιήσει τον λογαριασμό σας"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Μη έγκυρο ή ληγμένο token· παρακαλώ επαναδιαμορφώστε την ενσωμάτωση.",
+      "wrong_account": "Βεβαιωθείτε ότι επαναδιαμορφώνετε τον ίδιο λογαριασμό.",
+      "unknown": "Απέτυχε λόγω απροσδόκητου σφάλματος."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/en.json
+++ b/custom_components/daikin_onecta/translations/en.json
@@ -16,31 +16,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "The integration is already configured.",
-      "cannot_connect": "Failed to connect to Daikin Cloud.",
-      "init_failed": "Failed to initialize Daikin API.",
-      "invalid_token": "Invalid or expired token; please reconfigure the integration.",
-      "unknown": "Failed due to an unexpected error.",
-      "wrong_account": "Please ensure you reconfigure against the same account."
-    },
-    "error": {
-      "cannot_connect": "Failed to connect",
-      "device_fail": "Unexpected error",
-      "device_timeout": "Failed to connect",
-      "forbidden": "Invalid authentication",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "Email address",
-          "password": "Password"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Enter the email address and password you use to login to Daikin Cloud, then press Submit.",
-        "title": "Configure Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Daikin Onecta integration needs to re-authenticate your account"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Invalid or expired token; please reconfigure the integration.",
+      "wrong_account": "Please ensure you reconfigure against the same account.",
+      "unknown": "Failed due to an unexpected error."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/fi.json
+++ b/custom_components/daikin_onecta/translations/fi.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integraatio on jo määritetty.",
-      "cannot_connect": "Yhteys Daikin Cloudiin epäonnistui.",
-      "init_failed": "Daikin API:n alustus epäonnistui.",
-      "wrong_account": "Varmista, että suoritat uudelleenkonfiguroinnin samaa tiliä vasten."
-    },
-    "error": {
-      "cannot_connect": "Yhteys epäonnistui",
-      "device_fail": "Odottamaton virhe",
-      "device_timeout": "Yhteys epäonnistui",
-      "forbidden": "Virheellinen todennus",
-      "invalid_auth": "Virheellinen todennus",
-      "unknown": "Odottamaton virhe"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "Sähköpostiosoite",
-          "password": "Salasana"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Syötä sähköpostiosoite ja salasana, joita käytät kirjautuaksesi Daikin Cloudiin, ja paina Lähetä.",
-        "title": "Määritä Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Daikin Onecta -integraation on todennettava tilisi uudelleen"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Virheellinen tai vanhentunut tunnus; määritä integrointi uudelleen.",
+      "wrong_account": "Varmista, että määrität uudelleen saman tilin.",
+      "unknown": "Epäonnistui odottamattoman virheen vuoksi."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/fr.json
+++ b/custom_components/daikin_onecta/translations/fr.json
@@ -34,25 +34,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "L'appareil est d\u00e9j\u00e0 configur\u00e9",
-      "cannot_connect": "\u00c9chec de connexion"
-    },
-    "error": {
-      "device_fail": "Erreur inattendue",
-      "device_timeout": "Echec de la connexion",
-      "forbidden": "Authentification invalide"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "host": "Nom d'h\u00f4te ou adresse IP",
-          "key": "Cl\u00e9 d'authentification (utilis\u00e9e uniquement par les appareils BRP072C/Zena)",
-          "password": "Mot de passe de l'appareil (utilis\u00e9 uniquement par les appareils SKYFi)"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Saisissez l'adresse IP de votre Daikin AC. \n\n Notez que Cl\u00e9 d'API et Mot de passe sont utilis\u00e9s respectivement par les p\u00e9riph\u00e9riques BRP072Cxx et SKYFi.",
-        "title": "Configurer Daikin AC"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "L'intégration Daikin Onecta doit ré-authentifier votre compte"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Jeton invalide ou expiré ; veuillez reconfigurer l'intégration.",
+      "wrong_account": "Veuillez vous assurer de reconfigurer le même compte.",
+      "unknown": "Échec en raison d'une erreur inattendue."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   }
 }

--- a/custom_components/daikin_onecta/translations/hu.json
+++ b/custom_components/daikin_onecta/translations/hu.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Az integráció már be van állítva.",
-      "cannot_connect": "Nem sikerült csatlakozni a Daikin Cloudhoz.",
-      "init_failed": "Nem sikerült inicializálni a Daikin API-t.",
-      "wrong_account": "Kérjük, ugyanahhoz a Daikin Onecta Cloud fiókhoz konfigurálja újra a lekérdezés beállításait."
-    },
-    "error": {
-      "cannot_connect": "Sikertelen csatlakozás",
-      "device_fail": "Váratlan hiba",
-      "device_timeout": "Sikertelen csatlakozás időtúllépés miatt",
-      "forbidden": "Érvénytelen hitelesítés",
-      "invalid_auth": "Érvénytelen hitelesítés",
-      "unknown": "Váratlan hiba"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-mail cím",
-          "password": "Jelszó"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Adja meg a Daikin Cloud bejelentkezéshez használt e-mail címét és jelszavát, majd nyomja meg a Küldés gombot.",
-        "title": "Daikin Onecta beállítása"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "A Daikin Onecta integrációnak újra hitelesítenie kell a fiókodat"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Érvénytelen vagy lejárt token; konfiguráld újra az integrációt.",
+      "wrong_account": "Győződj meg róla, hogy ugyanazzal a fiókkal konfigurálod újra.",
+      "unknown": "Váratlan hiba miatt sikertelen."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/it.json
+++ b/custom_components/daikin_onecta/translations/it.json
@@ -15,30 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "L'integrazione \u00e8 gi\u00e0 configurata.",
-      "cannot_connect": "Impossibile connettersi",
-      "missing_config": "File tokenset.json non trovato nella directory di configurazione."
-    },
-    "error": {
-      "cannot_connect": "Impossibile connettersi",
-      "device_fail": "Errore imprevisto",
-      "device_timeout": "Impossibile connettersi",
-      "forbidden": "Autenticazione non valida",
-      "invalid_auth": "Autenticazione non valida",
-      "unknown": "Errore imprevisto"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "api_key": "Chiave API",
-          "host": "Host",
-          "key": "Chiave API",
-          "password": "Password"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Non \u00e8 necessario introdurre parametri di configurazione in questo menu.\n\nAssicurati solo di aver ottenuto il tuo file tokenset.json usando la procedura con il MITM proxy, e di averlo salvato nella tua directory di configurazione, poi premi Submit per procedere.",
-        "title": "Configura Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "L'integrazione Daikin Onecta deve riautenticare il tuo account"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Token non valido o scaduto; riconfigurare l'integrazione.",
+      "wrong_account": "Assicurati di riconfigurare lo stesso account.",
+      "unknown": "Operazione non riuscita a causa di un errore imprevisto."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {
@@ -114,7 +125,7 @@
         "name": "Temperatura del serbatoio"
       },
       "heatupmode": {
-        "name": "Modalit\u00E0 riscaldamento"
+        "name": "Modalità riscaldamento"
       },
       "outdoortemperature": {
         "name": "Temperatura esterna"
@@ -126,22 +137,22 @@
         "name": "Codice di errore"
       },
       "setpointmode": {
-        "name": "Modalit\u00E0 setpoint"
+        "name": "Modalità setpoint"
       },
       "powerfulmode": {
-        "name": "Modalit\u00E0 powerful"
+        "name": "Modalità powerful"
       },
       "roomtemperature": {
         "name": "Temperatura della stanza"
       },
       "onoffmode": {
-        "name": "Modalit\u00E0 On/Off"
+        "name": "Modalità On/Off"
       },
       "controlmode": {
-        "name": "Modalit\u00E0 di controllo"
+        "name": "Modalità di controllo"
       },
       "roomhumidity": {
-        "name": "Umidit\u00E0 della stanza"
+        "name": "Umidità della stanza"
       },
       "pm1concentration": {
         "name": "Concentrazione di PM1"
@@ -150,16 +161,16 @@
         "name": "Concentrazione di PM2.5"
       },
       "operationmode": {
-        "name": "Modalit\u00E0 operativa"
+        "name": "Modalità operativa"
       },
       "airpurificationmode": {
-        "name": "Modalit\u00E0 purificazione d'aria"
+        "name": "Modalità purificazione d'aria"
       },
       "wificonnectionssid": {
         "name": "SSID della rete WiFi"
       },
       "wificonnectionstrength": {
-        "name": "Intensit\u00E0 del segnale WiFi"
+        "name": "Intensità del segnale WiFi"
       },
       "ssid": {
         "name": "SSID"
@@ -186,7 +197,7 @@
         "name": "Impostazione mantenimento asciutto"
       },
       "fanmotorrotationspeed": {
-        "name": "Velocit\u00E0 di rotazione della ventola del motore"
+        "name": "Velocità di rotazione della ventola del motore"
       },
       "datetime": {
         "name": "Data/Ora"
@@ -200,7 +211,7 @@
     },
     "binary_sensor": {
       "isholidaymodeactive": {
-        "name": "Modalit\u00E0 vacanza attiva"
+        "name": "Modalità vacanza attiva"
       },
       "isinerrorstate": {
         "name": "Stato di errore"
@@ -215,13 +226,13 @@
         "name": "Stato di emergenza"
       },
       "ispowerfulmodeactive": {
-        "name": "Modalit\u00E0 powerful attiva"
+        "name": "Modalità powerful attiva"
       },
       "iscoolheatmaster": {
         "name": "Is cool/heat master"
       },
       "isinmodeconflict": {
-        "name": "Modalit\u00E0 in conflitto"
+        "name": "Modalità in conflitto"
       },
       "isincautionstate": {
         "name": "Stato di cautela"
@@ -272,12 +283,12 @@
   },
   "issues": {
     "day_rate_limit": {
-      "title": "Il limite giornaliero di richieste \u00E8 stato raggiunto",
+      "title": "Il limite giornaliero di richieste è stato raggiunto",
       "description": "Hai raggiunto il limite giornaliero di richieste verso il Cloud Daikin, controlla la tua frequenza di polling nella configurazione Daikin Onecta."
     },
     "minute_rate_limit": {
-      "title": "Il limite per minuto di richieste \u00E8 stato raggiunto",
-      "description": "Hai raggiunto il limite per minuto di richieste verso il Cloud Daikin, non fare cos\u00EC tante chiamate al servizio Daikin in un minuto."
+      "title": "Il limite per minuto di richieste è stato raggiunto",
+      "description": "Hai raggiunto il limite per minuto di richieste verso il Cloud Daikin, non fare così tante chiamate al servizio Daikin in un minuto."
     }
   },
   "system_health": {

--- a/custom_components/daikin_onecta/translations/nb.json
+++ b/custom_components/daikin_onecta/translations/nb.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integrasjonen er allerede konfigurert.",
-      "cannot_connect": "Kunne ikke koble til Daikin Cloud.",
-      "init_failed": "Kunne ikke initialisere Daikin API.",
-      "wrong_account": "Pass på at du konfigurerer på nytt mot den samme kontoen"
-    },
-    "error": {
-      "cannot_connect": "Kunne ikke koble til (tilkobling)",
-      "device_fail": "Uventet feil",
-      "device_timeout": "Kunne ikke koble til (timeout)",
-      "forbidden": "Ugyldig autentisering",
-      "invalid_auth": "Ugyldig autentisering",
-      "unknown": "Uventet feil"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-postadresse",
-          "password": "Passord"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Skriv inn IP adresse av Daikin AC.\n\n Merk at API-n\u00f8kkel og Passord bare brukes av henholdsvis BRP072Cxx og SKYFi-enheter.",
-        "title": "Konfigurer Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Daikin Onecta-integrasjonen må autentisere kontoen din på nytt"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ugyldig eller utløpt token; konfigurer integrasjonen på nytt.",
+      "wrong_account": "Sørg for at du konfigurerer på nytt mot samme konto.",
+      "unknown": "Mislyktes på grunn av en uventet feil."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/nl.json
+++ b/custom_components/daikin_onecta/translations/nl.json
@@ -15,28 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "De integratie is al geconfigureerd.",
-      "cannot_connect": "Verbinding met Daikin Cloud mislukt.",
-      "init_failed": "Initialiseren van de Daikin API is mislukt."
-    },
-    "error": {
-      "cannot_connect": "Verbinding mislukt",
-      "device_fail": "Onverwachte fout",
-      "device_timeout": "Verbinding mislukt",
-      "forbidden": "Ongeldige authenticatie",
-      "invalid_auth": "Ongeldige authenticatie",
-      "unknown": "Onverwachte fout"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E‑mailadres",
-          "password": "Wachtwoord"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Voer het e‑mailadres en wachtwoord in waarmee je inlogt op Daikin Cloud en druk daarna op Verzenden.",
-        "title": "Daikin Onecta configureren"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "De Daikin Onecta integratie moet je account opnieuw authenticeren"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ongeldige of verlopen token; configureer de integratie opnieuw.",
+      "wrong_account": "Zorg dat je opnieuw configureert met hetzelfde account.",
+      "unknown": "Mislukt door een onverwachte fout."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/nn.json
+++ b/custom_components/daikin_onecta/translations/nn.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integrasjonen er allereie konfigurert.",
-      "cannot_connect": "Kunne ikkje koble til Daikin Cloud.",
-      "init_failed": "Kunne ikkje initialisere Daikin API.",
-      "wrong_account": "Pass på at du konfigurerer på nytt mot den same kontoen"
-    },
-    "error": {
-      "cannot_connect": "Kunne ikkje koble til (tilkobling)",
-      "device_fail": "Uventa feil",
-      "device_timeout": "Kunne ikkje koble til (timeout)",
-      "forbidden": "Ugyldig autentisering",
-      "invalid_auth": "Ugyldig autentisering",
-      "unknown": "Uventa feil"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-postadresse",
-          "password": "Passord"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Skriv inn IP-adressa til Daikin AC.\n\nMerk at API-nøkkel og passord berre vert brukt av henholdsvis BRP072Cxx og SKYFi-einingar.",
-        "title": "Konfigurer Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Daikin Onecta-integrasjonen må autentisere kontoen din på nytt"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ugyldig eller utløpt token; konfigurer integrasjonen på nytt.",
+      "wrong_account": "Sørg for at du konfigurerer på nytt mot same konto.",
+      "unknown": "Mislyktest på grunn av ein uventa feil."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/no.json
+++ b/custom_components/daikin_onecta/translations/no.json
@@ -15,28 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integrasjonen er allerede konfigurert.",
-      "cannot_connect": "Kunne ikke koble til Daikin Cloud.",
-      "init_failed": "Kunne ikke initialisere Daikin API."
-    },
-    "error": {
-      "cannot_connect": "Kunne ikke koble til (tilkobling)",
-      "device_fail": "Uventet feil",
-      "device_timeout": "Kunne ikke koble til (timeout)",
-      "forbidden": "Ugyldig autentisering",
-      "invalid_auth": "Ugyldig autentisering",
-      "unknown": "Uventet feil"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-postadresse",
-          "password": "Passord"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Skriv inn IP adresse av Daikin AC.\n\n Merk at API-n\u00f8kkel og Passord bare brukes av henholdsvis BRP072Cxx og SKYFi-enheter.",
-        "title": "Konfigurer Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Daikin Onecta-integrasjonen må autentisere kontoen din på nytt"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ugyldig eller utløpt token; konfigurer integrasjonen på nytt.",
+      "wrong_account": "Sørg for at du konfigurerer på nytt mot samme konto.",
+      "unknown": "Mislyktes på grunn av en uventet feil."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/sk.json
+++ b/custom_components/daikin_onecta/translations/sk.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integrácia je už nakonfigurovaná.",
-      "cannot_connect": "Nepodarilo sa pripojiť k Daikin Cloud.",
-      "init_failed": "Nepodarilo sa inicializovať rozhranie Daikin API.",
-      "wrong_account": "Uistite sa prosím, že rekonfigurujete s rovnakým účtom."
-    },
-    "error": {
-      "cannot_connect": "Nepodarilo sa pripojiť",
-      "device_fail": "Neočakávaná chyba",
-      "device_timeout": "Časový limit pripojenia vypršal",
-      "forbidden": "Neplatné overenie",
-      "invalid_auth": "Neplatné overenie",
-      "unknown": "Neočakávaná chyba"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-mailová adresa",
-          "password": "Heslo"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Zadajte e-mailovú adresu a heslo, ktoré používate na prihlásenie do Daikin Cloud, potom stlačte Odoslať.",
-        "title": "Konfigurácia Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Integrácia Daikin Onecta potrebuje znova overiť váš účet"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Neplatný alebo expirovaný token; prosím prekonfigurujte integráciu.",
+      "wrong_account": "Uistite sa, že prekonfigurujete rovnaký účet.",
+      "unknown": "Zlyhalo kvôli neočakávanej chybe."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/sl.json
+++ b/custom_components/daikin_onecta/translations/sl.json
@@ -15,28 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integracija je že konfigurirana.",
-      "cannot_connect": "Povezava s storitvijo Daikin Cloud ni uspela.",
-      "init_failed": "Inicializacija Daikin API ni uspela."
-    },
-    "error": {
-      "cannot_connect": "Povezava ni uspela",
-      "device_fail": "Nepričakovana napaka",
-      "device_timeout": "Povezava ni uspela",
-      "forbidden": "Neveljavna overitev",
-      "invalid_auth": "Neveljavna overitev",
-      "unknown": "Nepričakovana napaka"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-poštni naslov",
-          "password": "Geslo"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Vnesite e-poštni naslov in geslo, ki ju uporabljate za prijavo v Daikin Cloud, nato pritisnite Pošlji.",
-        "title": "Nastavitev Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Integracija Daikin Onecta mora znova overiti vaš račun"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Neveljaven ali potekel žeton; prosimo, ponovno konfigurirajte integracijo.",
+      "wrong_account": "Prepričajte se, da znova konfigurirate isti račun.",
+      "unknown": "Neuspešno zaradi nepričakovane napake."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/sv.json
+++ b/custom_components/daikin_onecta/translations/sv.json
@@ -15,29 +15,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Integrationen är redan konfigurerad.",
-      "cannot_connect": "Kunde inte ansluta till Daikin Cloud.",
-      "init_failed": "Kunde inte initialisera Daikin API",
-      "wrong_account": "Var god kontrollera att du konfigurerar mot samma konto."
-    },
-    "error": {
-      "cannot_connect": "Kunde inte ansluta",
-      "device_fail": "Ett oväntat fel uppstod",
-      "device_timeout": "Kunde inte ansluta",
-      "forbidden": "Felaktig autentisering",
-      "invalid_auth": "Felaktig autentisering",
-      "unknown": "Ett oväntat fel uppstod"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "E-postaddress",
-          "password": "Lösenord"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Ange mailadressen och lösenordet du använder för att logga in i Daikin Cloud, och tryck sedan Bekräfta.",
-        "title": "Konfigurera Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Daikin Onecta-integrationen behöver autentisera ditt konto igen"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Ogiltig eller utgången token; konfigurera om integrationen.",
+      "wrong_account": "Se till att du konfigurerar om mot samma konto.",
+      "unknown": "Misslyckades på grund av ett oväntat fel."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/custom_components/daikin_onecta/translations/uk.json
+++ b/custom_components/daikin_onecta/translations/uk.json
@@ -16,31 +16,41 @@
     }
   },
   "config": {
-    "abort": {
-      "already_configured": "Інтеграцію вже налаштовано.",
-      "cannot_connect": "Не вдалося підключитися до Daikin Cloud.",
-      "init_failed": "Не вдалося ініціалізувати Daikin API.",
-      "invalid_token": "Недійсний або прострочений токен; будь ласка, повторно налаштуйте інтеграцію.",
-      "unknown": "Сталася неочікувана помилка.",
-      "wrong_account": "Будь ласка, переконайтеся, що ви виконуєте повторне налаштування з тим самим обліковим записом."
-    },
-    "error": {
-      "cannot_connect": "Не вдалося підключитися",
-      "device_fail": "Неочікувана помилка",
-      "device_timeout": "Не вдалося підключитися",
-      "forbidden": "Недійсна автентифікація",
-      "invalid_auth": "Недійсна автентифікація",
-      "unknown": "Неочікувана помилка"
-    },
     "step": {
-      "user": {
+      "pick_implementation": {
         "data": {
-          "email": "Адреса електронної пошти",
-          "password": "Пароль"
+          "implementation": "[%key:common::config_flow::data::implementation%]"
         },
-        "description": "Введіть адресу електронної пошти та пароль, які ви використовуєте для входу в Daikin Cloud, а потім натисніть «Надіслати».",
-        "title": "Налаштування Daikin Onecta"
+        "data_description": {
+          "implementation": "[%key:common::config_flow::description::implementation%]"
+        },
+        "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Інтеграції Daikin Onecta потрібно повторно автентифікувати ваш обліковий запис"
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "invalid_token": "Недійсний або прострочений токен; будь ласка, переналаштуйте інтеграцію.",
+      "wrong_account": "Переконайтеся, що ви переналаштовуєте той самий обліковий запис.",
+      "unknown": "Не вдалося через неочікувану помилку."
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
   },
   "entity": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,71 @@
+"""Tests that setup translations match the OAuth2 config flow."""
+import json
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "daikin_onecta"
+TRANSLATIONS = COMPONENT / "translations"
+STRINGS = COMPONENT / "strings.json"
+
+# Abort reasons used by this integration and the HA OAuth2 flow helper
+REQUIRED_ABORT_KEYS = {
+    "already_configured",
+    "invalid_token",
+    "wrong_account",
+    "unknown",
+    "oauth_error",
+    "oauth_failed",
+    "oauth_implementation_unavailable",
+    "oauth_timeout",
+    "oauth_unauthorized",
+    "missing_configuration",
+    "authorize_url_timeout",
+    "no_url_available",
+    "user_rejected_authorize",
+    "reauth_successful",
+}
+
+REQUIRED_STEPS = {"pick_implementation", "reauth_confirm"}
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _translation_files() -> list[Path]:
+    return sorted(TRANSLATIONS.glob("*.json"))
+
+
+@pytest.mark.parametrize("path", _translation_files(), ids=lambda p: p.name)
+def test_config_translations_are_oauth2(path: Path) -> None:
+    """Setup translations must describe OAuth2, not email/password login."""
+    data = _load(path)
+    config = data["config"]
+
+    steps = set(config["step"])
+    assert REQUIRED_STEPS.issubset(steps), f"{path.name} missing steps: {REQUIRED_STEPS - steps}"
+    assert "user" not in steps, f"{path.name} still has obsolete email/password user step"
+
+    abort = set(config["abort"])
+    missing = REQUIRED_ABORT_KEYS - abort
+    assert not missing, f"{path.name} missing abort keys: {missing}"
+
+    reauth = config["step"]["reauth_confirm"]
+    assert "description" in reauth
+    assert "title" in reauth
+    assert "Daikin Onecta" in reauth["description"] or "daikin" in reauth["description"].lower()
+
+
+def test_strings_json_config_is_oauth2() -> None:
+    """strings.json is the English source and must match the OAuth2 flow."""
+    data = _load(STRINGS)
+    config = data["config"]
+
+    assert REQUIRED_STEPS.issubset(set(config["step"]))
+    assert "user" not in config["step"]
+    assert REQUIRED_ABORT_KEYS.issubset(set(config["abort"]))
+
+    pick = config["step"]["pick_implementation"]
+    assert "oauth2_pick_implementation" in pick["title"]
+    assert "implementation" in pick.get("data", {})


### PR DESCRIPTION
Fixes https://github.com/jwillemsen/daikin_onecta/issues/582

The setup strings still described the old email/password login flow, while the integration has used OAuth2 for a long time. That left wrong copy in the UI for setup and reauth, and missing abort keys for the OAuth2 helper.

## Changes
- Replace the obsolete email/password `user` step with `pick_implementation` and `reauth_confirm`
- Align `strings.json` and all language files with the abort reasons used by `AbstractOAuth2FlowHandler` and this integration (`invalid_token`, `wrong_account`, etc.)
- Leave entity/options/issues/system_health strings alone
- Add tests so the old password step cannot sneak back in

Tested locally with HA 2026.7.2: 52/52 passed (including 17 new translation tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the config flow UI to use OAuth2 “pick implementation” and reauthentication confirmation steps, with localized implementation text and standardized completion messaging.
* **Bug Fixes**
  * Refreshed/normalized Italian display and rate-limit issue text for consistency.
* **Tests**
  * Added automated translation validation to ensure required OAuth2 steps/abort keys are present and legacy email/password setup text is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->