### PR TITLE
Update homeassistant version in requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pre-commit==3.6.2
 flake8==7.0.0
 reorder-python-imports==3.12.0
-homeassistant==2026.07.04
+homeassistant==2026.08.0
 pytest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to use Home Assistant version 2026.08.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->