### PR TITLE
Fix density unit import for Home Assistant 2026.6

### DIFF
--- a/custom_components/daikin_onecta/const.py
+++ b/custom_components/daikin_onecta/const.py
@@ -4,13 +4,13 @@ from homeassistant.components.sensor import CONF_STATE_CLASS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.components.update import UpdateDeviceClass
+from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 from homeassistant.const import CONF_DEVICE_CLASS
 from homeassistant.const import CONF_ICON
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
 from homeassistant.const import PERCENTAGE
 from homeassistant.const import REVOLUTIONS_PER_MINUTE
 from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
-from homeassistant.const import UnitOfDensity
 from homeassistant.const import UnitOfEnergy
 from homeassistant.const import UnitOfPower
 from homeassistant.const import UnitOfTemperature
@@ -459,7 +459,7 @@ VALUE_SENSOR_MAPPING = {
     "pm1Concentration": {
         CONF_DEVICE_CLASS: SensorDeviceClass.PM1,
         CONF_STATE_CLASS: SensorStateClass.MEASUREMENT,
-        CONF_UNIT_OF_MEASUREMENT: UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        CONF_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         CONF_ICON: "mdi:blur",
         ENABLED_DEFAULT: True,
         ENTITY_CATEGORY: None,
@@ -468,7 +468,7 @@ VALUE_SENSOR_MAPPING = {
     "pm25Concentration": {
         CONF_DEVICE_CLASS: SensorDeviceClass.PM25,
         CONF_STATE_CLASS: SensorStateClass.MEASUREMENT,
-        CONF_UNIT_OF_MEASUREMENT: UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        CONF_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         CONF_ICON: "mdi:blur",
         ENABLED_DEFAULT: True,
         ENTITY_CATEGORY: None,
@@ -477,7 +477,7 @@ VALUE_SENSOR_MAPPING = {
     "pm10Concentration": {
         CONF_DEVICE_CLASS: SensorDeviceClass.PM10,
         CONF_STATE_CLASS: SensorStateClass.MEASUREMENT,
-        CONF_UNIT_OF_MEASUREMENT: UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
+        CONF_UNIT_OF_MEASUREMENT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         CONF_ICON: "mdi:blur",
         ENABLED_DEFAULT: True,
         ENTITY_CATEGORY: None,

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -81436,7 +81436,7 @@
     'supported_features': 0,
     'translation_key': 'pm10concentration',
     'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_climateControl_sensoryData_pm10Concentration',
-    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+    'unit_of_measurement': 'μg/m³',
   })
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm10_concentration-state]
@@ -81445,7 +81445,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm10',
       <EntityStateAttribute.ICON: 'icon'>: 'mdi:blur',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'μg/m³',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.air_purifier_climatecontrol_pm10_concentration',
@@ -81491,7 +81491,7 @@
     'supported_features': 0,
     'translation_key': 'pm1concentration',
     'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_climateControl_sensoryData_pm1Concentration',
-    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+    'unit_of_measurement': 'μg/m³',
   })
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm1_concentration-state]
@@ -81500,7 +81500,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm1',
       <EntityStateAttribute.ICON: 'icon'>: 'mdi:blur',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'μg/m³',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.air_purifier_climatecontrol_pm1_concentration',
@@ -81546,7 +81546,7 @@
     'supported_features': 0,
     'translation_key': 'pm25concentration',
     'unique_id': '1c80e348-61c1-4f0d-a8b1-917f2f904529_climateControl_sensoryData_pm25Concentration',
-    'unit_of_measurement': <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+    'unit_of_measurement': 'μg/m³',
   })
 # ---
 # name: test_mc80z[sensor.air_purifier_climatecontrol_pm2_5_concentration-state]
@@ -81555,7 +81555,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'pm25',
       <EntityStateAttribute.ICON: 'icon'>: 'mdi:blur',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfDensity.MICROGRAMS_PER_CUBIC_METER: 'μg/m³'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'μg/m³',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.air_purifier_climatecontrol_pm2_5_concentration',


### PR DESCRIPTION
## Summary

- replace the removed `UnitOfDensity` enum with Home Assistant's
  `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` constant
- update the affected air-quality sensor snapshots

## Problem

Starting with Home Assistant 2026.6, importing the integration fails during
setup because `UnitOfDensity` is no longer available from
`homeassistant.const`:

```text
ImportError: cannot import name 'UnitOfDensity' from 'homeassistant.const'
```

This prevents the entire `daikin_onecta` integration from loading.

## Testing

- verified the integration imports and runs on Home Assistant 2026.6.3
- ran `pytest -q tests/test_init.py` (26 test scenarios executed)
- ran `pre-commit run --all-files` successfully



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PM1, PM2.5, and PM10 air-quality sensors to display particulate concentration using the standard `μg/m³` unit.
  * Improved compatibility and consistency of air-quality sensor measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->