### PR TITLE
Propagate transient API network errors

### DIFF
--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import datetime
 
+from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant import core
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -124,6 +125,10 @@ class DaikinApi:
                         self._last_patch_call = datetime.now()
                         return True
 
+            except (ClientError, asyncio.TimeoutError):
+                # Propagate transient network errors so Home Assistant marks the
+                # coordinator update as failed and retries it.
+                raise
             except Exception as e:
                 _LOGGER.error("REQUEST TYPE %s FAILED: %s", method, e)
 

--- a/tests/test_daikin_api.py
+++ b/tests/test_daikin_api.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from aiohttp import ClientConnectionError
 from homeassistant.core import HomeAssistant
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.daikin_onecta.daikin_api import DaikinApi

--- a/tests/test_daikin_api.py
+++ b/tests/test_daikin_api.py
@@ -1,0 +1,41 @@
+"""Tests for the Daikin Onecta API client."""
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from aiohttp import ClientConnectionError
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.daikin_onecta.daikin_api import DaikinApi
+
+
+@pytest.mark.parametrize(
+    "error",
+    [ClientConnectionError("network unavailable"), asyncio.TimeoutError()],
+)
+async def test_get_device_details_propagates_network_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    error: Exception,
+) -> None:
+    """Transient network failures must reach the coordinator retry logic."""
+    session = MagicMock()
+    session.request.side_effect = error
+
+    with (
+        patch(
+            "custom_components.daikin_onecta.daikin_api.async_get_clientsession",
+            return_value=session,
+        ),
+        patch.object(
+            DaikinApi,
+            "async_get_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+        pytest.raises(type(error)),
+    ):
+        api = DaikinApi(hass, config_entry, MagicMock())
+        await api.getCloudDeviceDetails()


### PR DESCRIPTION
## Summary

- propagate `aiohttp.ClientError` and `asyncio.TimeoutError` from API requests
- retain the existing fallback handling for non-network exceptions
- add regression coverage for connection and timeout failures

## Why

A transient DNS failure during Home Assistant startup caused `getCloudDeviceDetails()` to return an empty list. The coordinator treated that as a successful refresh with no devices, leaving all climate entities unavailable indefinitely instead of invoking Home Assistant's retry handling.

Allowing transient network errors to reach the coordinator marks the refresh as failed and lets Home Assistant retry normally.

## Testing

- `pre-commit run --all-files`
- `pytest --timeout=9 -p no:sugar tests/test_daikin_api.py` — 2 passed
- full `pytest --timeout=9 -p no:sugar` — all 60 tests executed, but the suite exits 1 on 37 snapshot failures and 24 unused snapshots; the unmodified `master` branch has the identical snapshot result in the same Python 3.14 environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary network and timeout errors so Home Assistant can retry failed Daikin cloud requests.
  * Preserved existing fallback behavior for other unexpected errors.

* **Tests**
  * Added coverage for connection and timeout error propagation during device detail requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->