### PR TITLE
Fixed usage of cc without checking for None

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 1 * * SUN"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 1 * * SUN"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   precommit:
     runs-on: "ubuntu-slim"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 1 * * SUN"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: "ubuntu-slim"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,10 @@ on:
     - cron: "0 1 * * SUN"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/custom_components/daikin_onecta/binary_sensor.py
+++ b/custom_components/daikin_onecta/binary_sensor.py
@@ -69,8 +69,6 @@ async def async_setup_entry(
 
 
 class DaikinBinarySensor(CoordinatorEntity, BinarySensorEntity):
-
-
     def __init__(
         self,
         device: DaikinOnectaDevice,

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -831,21 +831,22 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
         return res
 
     def get_preset_mode(self):
-        cc = self.climate_control()
         current_preset_mode = PRESET_NONE
-        for mode in self.preset_modes:
-            daikin_mode = HA_PRESET_TO_DAIKIN[mode]
-            preset = cc.get(daikin_mode)
-            if preset is not None:
-                preset_value = preset.get("value")
-                if preset_value is not None:
-                    # for example holidayMode value is a dict object with an enabled value
-                    if isinstance(preset_value, dict):
-                        enabled_value = preset_value.get("enabled")
-                        if enabled_value is not None and enabled_value:
+        cc = self.climate_control()
+        if cc is not None:
+            for mode in self.preset_modes:
+                daikin_mode = HA_PRESET_TO_DAIKIN[mode]
+                preset = cc.get(daikin_mode)
+                if preset is not None:
+                    preset_value = preset.get("value")
+                    if preset_value is not None:
+                        # for example holidayMode value is a dict object with an enabled value
+                        if isinstance(preset_value, dict):
+                            enabled_value = preset_value.get("enabled")
+                            if enabled_value is not None and enabled_value:
+                                current_preset_mode = mode
+                        if preset_value == "on":
                             current_preset_mode = mode
-                    if preset_value == "on":
-                        current_preset_mode = mode
         return current_preset_mode
 
     async def async_set_preset_mode(self, preset_mode):

--- a/custom_components/daikin_onecta/climate.py
+++ b/custom_components/daikin_onecta/climate.py
@@ -905,19 +905,21 @@ class DaikinClimate(CoordinatorEntity, ClimateEntity):
     def get_preset_modes(self):
         supported_preset_modes = [PRESET_NONE]
         cc = self.climate_control()
-        for mode in PRESET_MODES:
-            daikin_mode = HA_PRESET_TO_DAIKIN[mode]
-            preset = cc.get(daikin_mode)
-            if preset is not None and preset.get("value") is not None:
-                supported_preset_modes.append(mode)
+        if cc is not None:
+            for mode in PRESET_MODES:
+                daikin_mode = HA_PRESET_TO_DAIKIN[mode]
+                preset = cc.get(daikin_mode)
+                if preset is not None and preset.get("value") is not None:
+                    supported_preset_modes.append(mode)
 
-        _LOGGER.debug(
-            "Device '%s' supports preset_modes %s",
-            self._device.name,
-            format(supported_preset_modes),
-        )
+            _LOGGER.debug(
+                "Device '%s' supports preset_modes %s",
+                self._device.name,
+                format(supported_preset_modes),
+            )
 
-        supported_preset_modes.sort()
+            supported_preset_modes.sort()
+
         return supported_preset_modes
 
     async def async_turn_on(self):


### PR DESCRIPTION
    * custom_components/daikin_onecta/climate.py

Fixed #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved climate preset handling for devices without available climate-control data.
  - Prevented errors when preset information is missing.
  - Devices without climate-control data now safely report no active preset and expose only the default preset option.
  - Preset detection continues to work as expected when climate-control information is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->