### PR TITLE
No need to log exceptions manuallu, already done by logger.exception

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -97,8 +97,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                         config_entry.data["token"]["access_token"],
                         options={"verify_signature": False},
                     )["sub"]
-                except (jwt.DecodeError, KeyError) as err:
-                    _LOGGER.exception("Failed to decode JWT during migration: %s", err)
+                except (jwt.DecodeError, KeyError):
+                    _LOGGER.exception("Failed to decode JWT during migration")
                     return False
                 hass.config_entries.async_update_entry(
                     config_entry,

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -103,8 +103,8 @@ class FlowHandler(
         """Create an oauth config entry or update existing entry for reauth."""
         try:
             unique_id = jwt.decode(data["token"]["access_token"], options={"verify_signature": False})["sub"]
-        except (jwt.DecodeError, KeyError) as err:
-            _LOGGER.exception("Failed to decode JWT: %s", err)
+        except (jwt.DecodeError, KeyError):
+            _LOGGER.exception("Failed to decode JWT")
             return self.async_abort(reason="invalid_token")
 
         await self.async_set_unique_id(unique_id)


### PR DESCRIPTION
    * custom_components/daikin_onecta/__init__.py:
    * custom_components/daikin_onecta/config_flow.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging for JWT migration and OAuth setup failures.
  - Removed potentially sensitive exception details from user authentication error logs.
  - Authentication flow behavior remains unchanged when invalid tokens are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->