### PR TITLE
Use dt_util

### DIFF
--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .daikin_api import DaikinApi
@@ -57,7 +58,7 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
         daikin_api = onecta_data.daikin_api
         scan_ignore_value = self.scan_ignore()
 
-        if (datetime.now() - daikin_api._last_patch_call).total_seconds() < scan_ignore_value:
+        if (dt_util.now() - daikin_api._last_patch_call).total_seconds() < scan_ignore_value:
             self.update_interval = timedelta(seconds=scan_ignore_value)
             _LOGGER.debug(
                 "API UPDATE skipped (just updated from UI)",
@@ -88,17 +89,17 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
         # Default of low scan minutes interval
         scan_interval = self.options.get("low_scan_interval", 30) * 60
         high_scan_interval = self.options.get("high_scan_interval", 10) * 60
-        hs = datetime.strptime(self.options.get("high_scan_start", "07:00:00"), "%H:%M:%S").time()
-        ls_datetime = datetime.strptime(self.options.get("low_scan_start", "22:00:00"), "%H:%M:%S")
-        ls = ls_datetime.time()
-        if self.in_between(datetime.now().time(), hs, ls):
+        hs = dt_util.parse_time(self.options.get("high_scan_start", "07:00:00"))
+        ls = dt_util.parse_time(self.options.get("low_scan_start", "22:00:00"))
+        if self.in_between(dt_util.now().time(), hs, ls):
             scan_interval = high_scan_interval
         else:
             # When switching from high to low frequency polling we need to randomize the first
             # poll so that we spread the load to daikin, so for example when we have a low start at
             # 22:00 and a high scan interval of 9 minutes we randomize the next poll when it is
             # between 22:00 and 22:09
-            if self.in_between(datetime.now().time(), ls, (ls_datetime + timedelta(seconds=high_scan_interval)).time()):
+            end_time = (dt_util.start_of_local_day() + timedelta(hours=ls.hour, minutes=ls.minute, seconds= ls.second + high_scan_interval)).time()
+            if self.in_between(dt_util.now().time(), ls, end_time):
                 scan_interval = random.randint(60, int(scan_interval))
 
         # When we hit our daily rate limit we check the retry_after which is the amount of seconds

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -2,7 +2,6 @@
 import logging
 import random
 from dataclasses import dataclass
-from datetime import datetime
 from datetime import timedelta
 from typing import Any
 
@@ -98,7 +97,7 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
             # poll so that we spread the load to daikin, so for example when we have a low start at
             # 22:00 and a high scan interval of 9 minutes we randomize the next poll when it is
             # between 22:00 and 22:09
-            end_time = (dt_util.start_of_local_day() + timedelta(hours=ls.hour, minutes=ls.minute, seconds= ls.second + high_scan_interval)).time()
+            end_time = (dt_util.start_of_local_day() + timedelta(hours=ls.hour, minutes=ls.minute, seconds=ls.second + high_scan_interval)).time()
             if self.in_between(dt_util.now().time(), ls, end_time):
                 scan_interval = random.randint(60, int(scan_interval))
 

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -57,7 +57,7 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
         daikin_api = onecta_data.daikin_api
         scan_ignore_value = self.scan_ignore()
 
-        if (dt_util.now() - daikin_api._last_patch_call).total_seconds() < scan_ignore_value:
+        if daikin_api._last_patch_call is not None and (dt_util.now() - daikin_api._last_patch_call).total_seconds() < scan_ignore_value:
             self.update_interval = timedelta(seconds=scan_ignore_value)
             _LOGGER.debug(
                 "API UPDATE skipped (just updated from UI)",

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -38,7 +38,8 @@ class DaikinApi:
         # immediately after a PATCH request. Se we use this attribute
         # to check when we had the last patch command, if it is less then
         # 10 seconds ago we skip the get
-        self._last_patch_call = dt_util.as_local(datetime.min)
+        # self._last_patch_call = dt_util.as_local(datetime.min)
+        self._last_patch_call: datetime | None = None
 
         # Store the limits as member so that we can add these to the diagnostics
         self.rate_limits = {

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -10,6 +10,7 @@ from homeassistant import core
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
 
 from .const import DAIKIN_API_URL
 from .const import DOMAIN
@@ -37,7 +38,7 @@ class DaikinApi:
         # immediately after a PATCH request. Se we use this attribute
         # to check when we had the last patch command, if it is less then
         # 10 seconds ago we skip the get
-        self._last_patch_call = datetime.min
+        self._last_patch_call = dt_util.as_local(datetime.min)
 
         # Store the limits as member so that we can add these to the diagnostics
         self.rate_limits = {
@@ -122,7 +123,7 @@ class DaikinApi:
                         else:
                             return False
                     elif resp.status == 204:
-                        self._last_patch_call = datetime.now()
+                        self._last_patch_call = dt_util.now()
                         return True
 
             except (ClientError, asyncio.TimeoutError):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.daikin_onecta.const import DOMAIN
 from custom_components.daikin_onecta.coordinator import OnectaDataUpdateCoordinator

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.daikin_onecta.const import DOMAIN
@@ -72,22 +71,18 @@ class TestOnectaDataUpdateCoordinator:
         assert coordinator.in_between(time(23, 0, 0), start, end)
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
-    def test_high_scan_interval(self, mock_datetime, coordinator, mock_hass):
+    def test_high_scan_interval(self, mock_now, coordinator, mock_hass):
         """High scan interval should apply during high-frequency window."""
-        mock_now = dt_util.as_local(datetime(2023, 1, 1, 10, 0, 0))
-        mock_datetime.now.return_value = mock_now
-        mock_datetime.strptime.side_effect = datetime.strptime
+        mock_now.return_value = datetime(2023, 1, 1, 10, 0, 0)
 
         expected = timedelta(minutes=10)
         result = coordinator.determine_update_interval(mock_hass)
         assert result == expected
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
-    def test_low_scan_interval(self, mock_datetime, coordinator, mock_hass):
+    def test_low_scan_interval(self, mock_now, coordinator, mock_hass):
         """Low scan interval should apply outside transition windows."""
-        mock_now = datetime(2023, 1, 1, 23, 0, 0)
-        mock_datetime.now.return_value = mock_now
-        mock_datetime.strptime.side_effect = datetime.strptime
+        mock_now.return_value = datetime(2023, 1, 1, 23, 0, 0)
 
         with patch.object(coordinator, "in_between", side_effect=[False, False]):
             expected = timedelta(minutes=30)
@@ -96,11 +91,9 @@ class TestOnectaDataUpdateCoordinator:
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     @patch("custom_components.daikin_onecta.coordinator.random")
-    def test_transition_period_randomization(self, mock_random, mock_datetime, coordinator, mock_hass):
+    def test_transition_period_randomization(self, mock_random, mock_now, coordinator, mock_hass):
         """During transition, interval is randomized between floor and low interval."""
-        mock_now = datetime(2023, 1, 1, 22, 5, 0)
-        mock_datetime.now.return_value = mock_now
-        mock_datetime.strptime.side_effect = datetime.strptime
+        mock_now.return_value = datetime(2023, 1, 1, 22, 5, 0)
         mock_random.randint.return_value = 120  # 2 minutes
 
         with patch.object(coordinator, "in_between", side_effect=[False, True]):
@@ -110,11 +103,9 @@ class TestOnectaDataUpdateCoordinator:
             mock_random.randint.assert_called_once_with(60, 1800)
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
-    def test_rate_limit_exceeded(self, mock_datetime, coordinator, mock_hass, mock_config_entry):
+    def test_rate_limit_exceeded(self, mock_now, coordinator, mock_hass, mock_config_entry):
         """When rate limit is exceeded, interval = retry_after + fallback (60s)."""
-        mock_now = datetime(2023, 1, 1, 23, 0, 0)
-        mock_datetime.now.return_value = mock_now
-        mock_datetime.strptime.side_effect = datetime.strptime
+        mock_now.return_value = datetime(2023, 1, 1, 23, 0, 0)
 
         # Simulate daily rate limit reached
         mock_config_entry.runtime_data.daikin_api.rate_limits = {"remaining_day": 0, "retry_after": 3000}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.util import dt as dt_util
 
 from custom_components.daikin_onecta.const import DOMAIN
 from custom_components.daikin_onecta.coordinator import OnectaDataUpdateCoordinator
@@ -73,7 +74,7 @@ class TestOnectaDataUpdateCoordinator:
     @patch("custom_components.daikin_onecta.coordinator.datetime")
     def test_high_scan_interval(self, mock_datetime, coordinator, mock_hass):
         """High scan interval should apply during high-frequency window."""
-        mock_now = datetime(2023, 1, 1, 10, 0, 0)
+        mock_now = dt_util.as_local(datetime(2023, 1, 1, 10, 0, 0))
         mock_datetime.now.return_value = mock_now
         mock_datetime.strptime.side_effect = datetime.strptime
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -71,7 +71,7 @@ class TestOnectaDataUpdateCoordinator:
         assert coordinator.in_between(time(22, 0, 0), start, end)
         assert coordinator.in_between(time(23, 0, 0), start, end)
 
-    @patch("custom_components.daikin_onecta.coordinator.datetime")
+    @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     def test_high_scan_interval(self, mock_datetime, coordinator, mock_hass):
         """High scan interval should apply during high-frequency window."""
         mock_now = dt_util.as_local(datetime(2023, 1, 1, 10, 0, 0))
@@ -82,7 +82,7 @@ class TestOnectaDataUpdateCoordinator:
         result = coordinator.determine_update_interval(mock_hass)
         assert result == expected
 
-    @patch("custom_components.daikin_onecta.coordinator.datetime")
+    @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     def test_low_scan_interval(self, mock_datetime, coordinator, mock_hass):
         """Low scan interval should apply outside transition windows."""
         mock_now = datetime(2023, 1, 1, 23, 0, 0)
@@ -94,7 +94,7 @@ class TestOnectaDataUpdateCoordinator:
             result = coordinator.determine_update_interval(mock_hass)
             assert result == expected
 
-    @patch("custom_components.daikin_onecta.coordinator.datetime")
+    @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     @patch("custom_components.daikin_onecta.coordinator.random")
     def test_transition_period_randomization(self, mock_random, mock_datetime, coordinator, mock_hass):
         """During transition, interval is randomized between floor and low interval."""
@@ -109,7 +109,7 @@ class TestOnectaDataUpdateCoordinator:
             assert result == expected
             mock_random.randint.assert_called_once_with(60, 1800)
 
-    @patch("custom_components.daikin_onecta.coordinator.datetime")
+    @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     def test_rate_limit_exceeded(self, mock_datetime, coordinator, mock_hass, mock_config_entry):
         """When rate limit is exceeded, interval = retry_after + fallback (60s)."""
         mock_now = datetime(2023, 1, 1, 23, 0, 0)


### PR DESCRIPTION
    * custom_components/daikin_onecta/coordinator.py:
    * custom_components/daikin_onecta/daikin_api.py:
    * tests/test_coordinator.py:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of local time zones when scheduling scans and tracking update intervals.
  - Fixed timestamp comparisons and patch timing to use timezone-aware values.
  - Improved reliability around daily scan transition windows and configured scan times.
  - Prevented update-throttling checks from failing when no previous update timestamp is available.
  - Scan schedules now more reliably reflect the configured local time, including transitions between normal and reduced scan periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->