### PR TITLE
Fixed HA 2026.08 warnings

### DIFF
--- a/custom_components/daikin_onecta/binary_sensor.py
+++ b/custom_components/daikin_onecta/binary_sensor.py
@@ -85,7 +85,7 @@ class DaikinBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._embedded_id = embedded_id

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -69,6 +69,10 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
                     devices[dev_data["id"]].setJsonData(dev_data)
                 else:
                     device = DaikinOnectaDevice(dev_data, daikin_api)
+                    # Register the gateway device in the device registry now, before
+                    # this coordinator's first refresh returns and platforms are set
+                    # up, so every platform can link back to it via via_device_id.
+                    device.async_register_ha_device(self.hass, self._config_entry)
                     devices[dev_data["id"]] = device
 
             self.update_interval = self.determine_update_interval(self.hass)

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -26,6 +28,13 @@ class DaikinOnectaDevice:
                 name = management_point["name"]["value"]
                 if name:
                     self.name = name
+
+        # Populated by async_register_ha_device() before any entity platform is set
+        # up. Sub-entities (per-management-point devices in sensor/water_heater/
+        # select/binary_sensor/switch/update) use this as via_device_id to link back
+        # to this gateway device: the older via_device=(DOMAIN, identifier) form is
+        # deprecated because identifiers are no longer guaranteed globally unique.
+        self.ha_device_id: str | None = None
 
         _LOGGER.info("Initialized Daikin Onecta Device '%s' (id %s)", self.name, self.id)
 
@@ -90,6 +99,22 @@ class DaikinOnectaDevice:
         self.fill_device_info(info, "gateway")
 
         return info
+
+    def async_register_ha_device(self, hass: HomeAssistant, config_entry) -> None:
+        """Eagerly create/update this device in the device registry.
+
+        Called once from the coordinator, before any entity platform is set up
+        (platforms are forwarded concurrently, so entity __init__ order across
+        platforms can't be relied on). This guarantees self.ha_device_id is
+        already populated by the time any platform builds a sub-device's
+        DeviceInfo with via_device_id=self.ha_device_id.
+        """
+        device_registry = dr.async_get(hass)
+        entry = device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            **self.device_info(),
+        )
+        self.ha_device_id = entry.id
 
     def setJsonData(self, desc):
         """Overwrite the json data for this device."""

--- a/custom_components/daikin_onecta/manifest.json
+++ b/custom_components/daikin_onecta/manifest.json
@@ -10,6 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jwillemsen/daikin_onecta/issues",
   "requirements": [],
+  "homeassistant": "2026.8.0",
   "version": "4.6.18",
   "zeroconf":
   [

--- a/custom_components/daikin_onecta/manifest.json
+++ b/custom_components/daikin_onecta/manifest.json
@@ -10,7 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jwillemsen/daikin_onecta/issues",
   "requirements": [],
-  "homeassistant": "2026.8.0",
   "version": "4.6.18",
   "zeroconf":
   [

--- a/custom_components/daikin_onecta/select.py
+++ b/custom_components/daikin_onecta/select.py
@@ -54,7 +54,7 @@ class DaikinScheduleSelect(CoordinatorEntity, SelectEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._embedded_id = embedded_id

--- a/custom_components/daikin_onecta/sensor.py
+++ b/custom_components/daikin_onecta/sensor.py
@@ -177,7 +177,7 @@ class DaikinEnergySensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._embedded_id = embedded_id
@@ -277,7 +277,7 @@ class DaikinValueSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._embedded_id = embedded_id
@@ -361,7 +361,7 @@ class DaikinLimitSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + "gateway")},
             "name": self._device.name + " " + "Gateway",
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, "gateway")
         self.update_state()

--- a/custom_components/daikin_onecta/switch.py
+++ b/custom_components/daikin_onecta/switch.py
@@ -107,7 +107,7 @@ class DaikinSwitch(CoordinatorEntity, ToggleEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self.update_state()

--- a/custom_components/daikin_onecta/update.py
+++ b/custom_components/daikin_onecta/update.py
@@ -90,7 +90,7 @@ class DaikinFirmwareUpdateEntity(CoordinatorEntity, UpdateEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name + " " + mpt,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._attr_has_entity_name = True

--- a/custom_components/daikin_onecta/water_heater.py
+++ b/custom_components/daikin_onecta/water_heater.py
@@ -62,7 +62,7 @@ class DaikinWaterTank(CoordinatorEntity, WaterHeaterEntity):
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device.id + self._management_point_type)},
             "name": self._device.name,
-            "via_device": (DOMAIN, self._device.id),
+            "via_device_id": self._device.ha_device_id,
         }
         self._device.fill_device_info(self._attr_device_info, management_point_type)
         self._attr_has_entity_name = True

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,5 +3,5 @@ pytest-homeassistant-custom-component
 anyio
 aiohttp_cors
 pytest-asyncio
-pytest-freezegun
+pytest-freezer
 setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # """Global fixtures for myenergi integration."""
+import asyncio
 import json
 import time
 from typing import Any
@@ -36,6 +37,22 @@ def load_fixture_json(name):
     with open(f"tests/fixtures/{name}.json") as json_file:
         data = json.load(json_file)
         return data
+
+
+async def resolve_system_health_coroutines(info: dict) -> dict:
+    """Await any coroutine values in a system_health info dict.
+
+    system_health_info() intentionally returns some values (e.g. from
+    system_health.async_check_can_reach_url) as unawaited coroutines: the real
+    system_health integration awaits these itself, concurrently, when
+    rendering the info page. Tests that call system_health_info() directly
+    need to await them too, or pytest emits "coroutine was never awaited"
+    RuntimeWarnings and the checks never actually run.
+    """
+    for key, value in info.items():
+        if asyncio.iscoroutine(value):
+            info[key] = await value
+    return info
 
 
 @pytest.fixture(name="auto_enable_custom_integrations", autouse=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Home Assistant device organization by linking sensors, controls, schedules, firmware updates, and water-heater entities to their associated gateway device.
  - Gateway devices are now registered earlier during setup, helping related entities appear under the correct parent device more reliably.
  - Updated device relationships to use Home Assistant’s current device-linking method for more consistent display and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->