### PR TITLE
Improve type annotations in integration core

### DIFF
--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except (OAuth2TokenRequestError, aiohttp.ClientError) as err:
         raise ConfigEntryNotReady from err
 
-    config_entry.runtime_data = OnectaRuntimeData(coordinator=None, daikin_api=daikin_api, devices={})
+    config_entry.runtime_data = OnectaRuntimeData(daikin_api=daikin_api, devices={})
     config_entry.runtime_data.coordinator = OnectaDataUpdateCoordinator(hass, config_entry)
 
     # Let the coordinator raise ConfigEntryAuthFailed / ConfigEntryNotReady directly.

--- a/custom_components/daikin_onecta/__init__.py
+++ b/custom_components/daikin_onecta/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import OAuth2TokenRequestError
 from homeassistant.exceptions import OAuth2TokenRequestReauthError
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import ImplementationUnavailableError
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .coordinator import OnectaDataUpdateCoordinator
@@ -32,7 +33,7 @@ PLATFORMS = [
 ]
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Setup the Daikin Onecta component."""
     return True
 
@@ -71,13 +72,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     return True
 
 
-async def async_unload_entry(hass, config_entry):
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading integration...")
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
 
-async def update_listener(hass, config_entry):
+async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Handle options update."""
     onecta_data: OnectaRuntimeData = config_entry.runtime_data
     coordinator = onecta_data.coordinator

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Config flow options handler for Daikin Onecta ."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize Daikin Onecta options flow."""
         self.options = dict(config_entry.options)
 
@@ -76,7 +76,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             errors=errors,
         )
 
-    async def _update_options(self):
+    async def _update_options(self) -> FlowResult:
         """Update config entry options."""
         return self.async_create_entry(title="", data=self.options)
 

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -2,8 +2,8 @@
 import logging
 import random
 from dataclasses import dataclass
+from datetime import time
 from datetime import timedelta
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -22,7 +22,7 @@ class OnectaRuntimeData:
     """Runtime Data for Onecta integration."""
 
     coordinator: "OnectaDataUpdateCoordinator"
-    devices: dict[str, Any]
+    devices: dict[str, DaikinOnectaDevice]
     daikin_api: DaikinApi
 
 
@@ -46,10 +46,12 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
             self.update_interval,
         )
 
-    def scan_ignore(self):
+    def scan_ignore(self) -> int:
+        """Return the delay after a write before polling resumes."""
         return self.options.get("scan_ignore", 30)
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> None:
+        """Fetch the latest device state from Daikin."""
         _LOGGER.debug("Daikin coordinator start _async_update_data.")
 
         onecta_data: OnectaRuntimeData = self._config_entry.runtime_data
@@ -82,13 +84,15 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
             self.update_interval,
         )
 
-    def update_settings(self, config_entry: ConfigEntry):
+    def update_settings(self, config_entry: ConfigEntry) -> None:
+        """Apply updated config entry options."""
         _LOGGER.debug("Daikin coordinator updating settings.")
         self.options = config_entry.options
         self.update_interval = self.determine_update_interval(self.hass)
         _LOGGER.info("Daikin coordinator changed interval to '%s'", self.update_interval)
 
-    def determine_update_interval(self, hass: HomeAssistant):
+    def determine_update_interval(self, hass: HomeAssistant) -> timedelta:
+        """Determine the next polling interval."""
         # Default of low scan minutes interval
         scan_interval = self.options.get("low_scan_interval", 30) * 60
         high_scan_interval = self.options.get("high_scan_interval", 10) * 60
@@ -113,8 +117,9 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
 
         return timedelta(seconds=scan_interval)
 
-    def in_between(self, now, start, end):
+    @staticmethod
+    def in_between(now: time, start: time, end: time) -> bool:
+        """Return whether now is between start and end, including overnight ranges."""
         if start <= end:
             return start <= now < end
-        else:
-            return start <= now or now < end
+        return start <= now or now < end

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -2,6 +2,7 @@
 import logging
 import random
 from dataclasses import dataclass
+from dataclasses import field
 from datetime import time
 from datetime import timedelta
 
@@ -21,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class OnectaRuntimeData:
     """Runtime Data for Onecta integration."""
 
-    coordinator: "OnectaDataUpdateCoordinator"
+    coordinator: "OnectaDataUpdateCoordinator" = field(init=False)
     devices: dict[str, DaikinOnectaDevice]
     daikin_api: DaikinApi
 
@@ -98,6 +99,7 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
         high_scan_interval = self.options.get("high_scan_interval", 10) * 60
         hs = dt_util.parse_time(self.options.get("high_scan_start", "07:00:00"))
         ls = dt_util.parse_time(self.options.get("low_scan_start", "22:00:00"))
+        assert hs is not None and ls is not None
         if self.in_between(dt_util.now().time(), hs, ls):
             scan_interval = high_scan_interval
         else:

--- a/custom_components/daikin_onecta/diagnostics.py
+++ b/custom_components/daikin_onecta/diagnostics.py
@@ -12,7 +12,8 @@ from .coordinator import OnectaRuntimeData
 REDACT_KEYS = {"serialNumber", "macAddress"}
 
 
-def get_entities(hass: HomeAssistant, config_entry: ConfigEntry):
+def get_entities(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[str, dict[str, Any]]:
+    """Return entity diagnostics for a config entry."""
     entity_registry = er.async_get(hass)
     entities_data: dict[str, dict[str, Any]] = {}
 
@@ -53,7 +54,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, config_entry: 
 
 async def async_get_device_diagnostics(hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry) -> dict[str, Any]:
     """Return diagnostics for a device entry."""
-    data = {}
+    data: dict[str, Any] = {}
     dev_id = next(iter(device.identifiers))[1]
     onecta_data: OnectaRuntimeData = config_entry.runtime_data
     daikin_api = onecta_data.daikin_api

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,8 @@ async def snapshot_platform_entities(
     snapshot: SnapshotAssertion,
     fixture_device_json,
 ) -> None:
-    config_entry.runtime_data = OnectaRuntimeData(daikin_api=MagicMock(), coordinator=MagicMock(), devices={})
+    config_entry.runtime_data = OnectaRuntimeData(daikin_api=MagicMock(), devices={})
+    config_entry.runtime_data.coordinator = MagicMock()
     """Snapshot entities and their states."""
     with (
         patch(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -25,7 +25,8 @@ def mock_hass():
 def mock_config_entry() -> MockConfigEntry:
     """Mock a config entry."""
     entry = MockConfigEntry(domain=DOMAIN, title="daikin_onecta", unique_id="12345")
-    entry.runtime_data = OnectaRuntimeData(daikin_api=MagicMock(), coordinator=MagicMock(), devices={})
+    entry.runtime_data = OnectaRuntimeData(daikin_api=MagicMock(), devices={})
+    entry.runtime_data.coordinator = MagicMock()
     return entry
 
 


### PR DESCRIPTION
Improve typing in the core Daikin Onecta integration without changing entity behavior.

Changes include:
- type Home Assistant setup/unload/update callbacks
- tighten `OnectaRuntimeData.devices` to `dict[str, DaikinOnectaDevice]`
- model the coordinator field with `dataclasses.field(init=False)` instead of initializing a non-optional field with `None`
- add return/argument annotations to coordinator helpers
- type diagnostics helper results
- type config-flow helper methods
- add small docstrings where required by the newly typed helpers

This is intentionally a conservative typing pass. It does not introduce typed Daikin API payload models yet; that belongs with the planned API/library split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type clarity and consistency across integration setup, configuration, data coordination, and diagnostics workflows.
  * Clarified lifecycle operations, update scheduling, device data handling, and diagnostic structures.
  * No user-facing behavior changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->