### PR TITLE
Use coordinator retry-after for Daikin rate limits

### DIFF
--- a/custom_components/daikin_onecta/button.py
+++ b/custom_components/daikin_onecta/button.py
@@ -57,5 +57,4 @@ class DaikinRefreshButton(CoordinatorEntity, ButtonEntity):
         self.async_write_ha_state()
 
     async def async_press(self) -> None:
-        await self.coordinator._async_update_data()
-        self.coordinator.async_update_listeners()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/daikin_onecta/button.py
+++ b/custom_components/daikin_onecta/button.py
@@ -57,4 +57,4 @@ class DaikinRefreshButton(CoordinatorEntity, ButtonEntity):
         self.async_write_ha_state()
 
     async def async_press(self) -> None:
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/custom_components/daikin_onecta/coordinator.py
+++ b/custom_components/daikin_onecta/coordinator.py
@@ -8,10 +8,12 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .daikin_api import DaikinApi
+from .daikin_api import DaikinRateLimitError
 from .device import DaikinOnectaDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +65,14 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
                 "API UPDATE skipped (just updated from UI)",
             )
         else:
-            daikin_api.json_data = await daikin_api.getCloudDeviceDetails()
+            try:
+                daikin_api.json_data = await daikin_api.getCloudDeviceDetails()
+            except DaikinRateLimitError as err:
+                raise UpdateFailed(
+                    "Daikin API rate limit exceeded",
+                    retry_after=err.retry_after,
+                ) from err
+
             for dev_data in daikin_api.json_data or []:
                 if dev_data["id"] in devices:
                     devices[dev_data["id"]].setJsonData(dev_data)
@@ -104,12 +113,6 @@ class OnectaDataUpdateCoordinator(DataUpdateCoordinator):
             end_time = (dt_util.start_of_local_day() + timedelta(hours=ls.hour, minutes=ls.minute, seconds=ls.second + high_scan_interval)).time()
             if self.in_between(dt_util.now().time(), ls, end_time):
                 scan_interval = random.randint(60, int(scan_interval))
-
-        # When we hit our daily rate limit we check the retry_after which is the amount of seconds
-        # we have to wait before we can make a call again
-        daikin_api = self._config_entry.runtime_data.daikin_api
-        if daikin_api.rate_limits["remaining_day"] == 0:
-            scan_interval = max(daikin_api.rate_limits["retry_after"] + 60, scan_interval)
 
         return timedelta(seconds=scan_interval)
 

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -42,7 +42,15 @@ class DaikinApi:
         self._config_entry = entry
         self.session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
         self._daikin_session = async_get_clientsession(hass)
+
+        # The Daikin cloud returns old settings if queried with a GET
+        # immediately after a PATCH request. Se we use this attribute
+        # to check when we had the last patch command, if it is less then
+        # 10 seconds ago we skip the get
+        # self._last_patch_call = dt_util.as_local(datetime.min)
         self._last_patch_call: datetime | None = None
+
+        # Store the limits as member so that we can add these to the diagnostics
         self.rate_limits = {
             "minute": 0,
             "day": 0,
@@ -51,7 +59,11 @@ class DaikinApi:
             "retry_after": 0,
             "ratelimit_reset": 0,
         }
+
+        # The following lock is used to serialize http requests to Daikin cloud
+        # to prevent receiving old settings while a PATCH is ongoing.
         self._cloud_lock = asyncio.Lock()
+
         _LOGGER.debug("Daikin Onecta API initialized.")
 
     async def async_get_access_token(self) -> str:
@@ -61,7 +73,9 @@ class DaikinApi:
     async def doBearerRequest(self, method, resource_url, options=None):
         async with self._cloud_lock:
             token = await self.async_get_access_token()
+
             headers = {"Accept-Encoding": "gzip", "Authorization": "Bearer " + token, "Content-Type": "application/json"}
+
             _LOGGER.debug("Request URL: %s", resource_url)
             _LOGGER.debug("Request %s Options: %s", method, options)
 
@@ -69,6 +83,7 @@ class DaikinApi:
                 async with self._daikin_session.request(method=method, url=DAIKIN_API_URL + resource_url, headers=headers, data=options) as resp:
                     response_data = await resp.text()
                     _LOGGER.debug("Response status: %s Text: %s Limit: %s", resp.status, response_data, self.rate_limits)
+
                     self.rate_limits["minute"] = int(resp.headers.get("X-RateLimit-Limit-minute", 0))
                     self.rate_limits["day"] = int(resp.headers.get("X-RateLimit-Limit-day", 0))
                     self.rate_limits["remaining_minutes"] = int(resp.headers.get("X-RateLimit-Remaining-minute", 0))
@@ -78,6 +93,7 @@ class DaikinApi:
 
                     if self.rate_limits["remaining_minutes"] > 0:
                         ir.async_delete_issue(self.hass, DOMAIN, "minute_rate_limit")
+
                     if self.rate_limits["remaining_day"] > 0:
                         ir.async_delete_issue(self.hass, DOMAIN, "day_rate_limit")
 
@@ -100,6 +116,7 @@ class DaikinApi:
                                 learn_more_url="https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/general_api_guidelines#doc-heading-rate-limitation",
                                 translation_key="minute_rate_limit",
                             )
+
                         if self.rate_limits["remaining_day"] == 0:
                             ir.async_create_issue(
                                 self.hass,
@@ -123,6 +140,8 @@ class DaikinApi:
                         return True
 
             except (ClientError, asyncio.TimeoutError, DaikinRateLimitError):
+                # Propagate transient network errors so Home Assistant marks the
+                # coordinator update as failed and retries it.
                 raise
             except Exception as e:
                 _LOGGER.error("REQUEST TYPE %s FAILED: %s", method, e)

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -18,6 +18,15 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+class DaikinRateLimitError(Exception):
+    """Raised when the Daikin API rate limit is exceeded."""
+
+    def __init__(self, retry_after: int) -> None:
+        """Initialize a rate limit error."""
+        super().__init__(f"Daikin API rate limit exceeded; retry after {retry_after} seconds")
+        self.retry_after = retry_after
+
+
 class DaikinApi:
     """Daikin Onecta API."""
 
@@ -33,15 +42,7 @@ class DaikinApi:
         self._config_entry = entry
         self.session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
         self._daikin_session = async_get_clientsession(hass)
-
-        # The Daikin cloud returns old settings if queried with a GET
-        # immediately after a PATCH request. Se we use this attribute
-        # to check when we had the last patch command, if it is less then
-        # 10 seconds ago we skip the get
-        # self._last_patch_call = dt_util.as_local(datetime.min)
         self._last_patch_call: datetime | None = None
-
-        # Store the limits as member so that we can add these to the diagnostics
         self.rate_limits = {
             "minute": 0,
             "day": 0,
@@ -50,11 +51,7 @@ class DaikinApi:
             "retry_after": 0,
             "ratelimit_reset": 0,
         }
-
-        # The following lock is used to serialize http requests to Daikin cloud
-        # to prevent receiving old settings while a PATCH is ongoing.
         self._cloud_lock = asyncio.Lock()
-
         _LOGGER.debug("Daikin Onecta API initialized.")
 
     async def async_get_access_token(self) -> str:
@@ -64,9 +61,7 @@ class DaikinApi:
     async def doBearerRequest(self, method, resource_url, options=None):
         async with self._cloud_lock:
             token = await self.async_get_access_token()
-
             headers = {"Accept-Encoding": "gzip", "Authorization": "Bearer " + token, "Content-Type": "application/json"}
-
             _LOGGER.debug("Request URL: %s", resource_url)
             _LOGGER.debug("Request %s Options: %s", method, options)
 
@@ -74,7 +69,6 @@ class DaikinApi:
                 async with self._daikin_session.request(method=method, url=DAIKIN_API_URL + resource_url, headers=headers, data=options) as resp:
                     response_data = await resp.text()
                     _LOGGER.debug("Response status: %s Text: %s Limit: %s", resp.status, response_data, self.rate_limits)
-
                     self.rate_limits["minute"] = int(resp.headers.get("X-RateLimit-Limit-minute", 0))
                     self.rate_limits["day"] = int(resp.headers.get("X-RateLimit-Limit-day", 0))
                     self.rate_limits["remaining_minutes"] = int(resp.headers.get("X-RateLimit-Remaining-minute", 0))
@@ -84,7 +78,6 @@ class DaikinApi:
 
                     if self.rate_limits["remaining_minutes"] > 0:
                         ir.async_delete_issue(self.hass, DOMAIN, "minute_rate_limit")
-
                     if self.rate_limits["remaining_day"] > 0:
                         ir.async_delete_issue(self.hass, DOMAIN, "day_rate_limit")
 
@@ -95,7 +88,7 @@ class DaikinApi:
                             _LOGGER.exception("Retrieve JSON failed: %s", response_data)
                             return []
 
-                    elif resp.status == 429:
+                    if resp.status == 429:
                         if self.rate_limits["remaining_minutes"] == 0:
                             ir.async_create_issue(
                                 self.hass,
@@ -107,7 +100,6 @@ class DaikinApi:
                                 learn_more_url="https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/general_api_guidelines#doc-heading-rate-limitation",
                                 translation_key="minute_rate_limit",
                             )
-
                         if self.rate_limits["remaining_day"] == 0:
                             ir.async_create_issue(
                                 self.hass,
@@ -120,16 +112,17 @@ class DaikinApi:
                                 translation_key="day_rate_limit",
                             )
                         if method == "GET":
-                            return []
-                        else:
-                            return False
-                    elif resp.status == 204:
+                            retry_after = max(self.rate_limits["retry_after"], 60)
+                            if self.rate_limits["remaining_day"] == 0:
+                                retry_after += 60
+                            raise DaikinRateLimitError(retry_after)
+                        return False
+
+                    if resp.status == 204:
                         self._last_patch_call = dt_util.now()
                         return True
 
-            except (ClientError, asyncio.TimeoutError):
-                # Propagate transient network errors so Home Assistant marks the
-                # coordinator update as failed and retries it.
+            except (ClientError, asyncio.TimeoutError, DaikinRateLimitError):
                 raise
             except Exception as e:
                 _LOGGER.error("REQUEST TYPE %s FAILED: %s", method, e)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -39,8 +39,8 @@ def coordinator(mock_hass, mock_config_entry):
     config_entry = mock_config_entry
     config_entry.add_to_hass(mock_hass)
     options = {
-        "low_scan_interval": 30,
-        "high_scan_interval": 10,
+        "low_scan_interval": 30,  # minutes
+        "high_scan_interval": 10,  # minutes
         "high_scan_start": "07:00:00",
         "low_scan_start": "22:00:00",
     }
@@ -78,23 +78,32 @@ class TestOnectaDataUpdateCoordinator:
     def test_high_scan_interval(self, mock_now, coordinator, mock_hass):
         """High scan interval should apply during high-frequency window."""
         mock_now.return_value = datetime(2023, 1, 1, 10, 0, 0)
-        assert coordinator.determine_update_interval(mock_hass) == timedelta(minutes=10)
+
+        expected = timedelta(minutes=10)
+        result = coordinator.determine_update_interval(mock_hass)
+        assert result == expected
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     def test_low_scan_interval(self, mock_now, coordinator, mock_hass):
         """Low scan interval should apply outside transition windows."""
         mock_now.return_value = datetime(2023, 1, 1, 23, 0, 0)
+
         with patch.object(coordinator, "in_between", side_effect=[False, False]):
-            assert coordinator.determine_update_interval(mock_hass) == timedelta(minutes=30)
+            expected = timedelta(minutes=30)
+            result = coordinator.determine_update_interval(mock_hass)
+            assert result == expected
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     @patch("custom_components.daikin_onecta.coordinator.random")
     def test_transition_period_randomization(self, mock_random, mock_now, coordinator, mock_hass):
         """During transition, interval is randomized between floor and low interval."""
         mock_now.return_value = datetime(2023, 1, 1, 22, 5, 0)
-        mock_random.randint.return_value = 120
+        mock_random.randint.return_value = 120  # 2 minutes
+
         with patch.object(coordinator, "in_between", side_effect=[False, True]):
-            assert coordinator.determine_update_interval(mock_hass) == timedelta(seconds=120)
+            expected = timedelta(seconds=120)
+            result = coordinator.determine_update_interval(mock_hass)
+            assert result == expected
             mock_random.randint.assert_called_once_with(60, 1800)
 
     async def test_rate_limit_uses_update_failed_retry_after(self, coordinator, mock_config_entry):
@@ -103,6 +112,7 @@ class TestOnectaDataUpdateCoordinator:
         daikin_api._last_patch_call = None
         daikin_api.getCloudDeviceDetails = AsyncMock(side_effect=DaikinRateLimitError(3060))
 
+        # Simulate daily rate limit reached
         with pytest.raises(UpdateFailed) as exc_info:
             await coordinator._async_update_data()
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,16 +2,19 @@
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.daikin_onecta.const import DOMAIN
 from custom_components.daikin_onecta.coordinator import OnectaDataUpdateCoordinator
 from custom_components.daikin_onecta.coordinator import OnectaRuntimeData
+from custom_components.daikin_onecta.daikin_api import DaikinRateLimitError
 
 
 @pytest.fixture
@@ -35,8 +38,8 @@ def coordinator(mock_hass, mock_config_entry):
     config_entry = mock_config_entry
     config_entry.add_to_hass(mock_hass)
     options = {
-        "low_scan_interval": 30,  # minutes
-        "high_scan_interval": 10,  # minutes
+        "low_scan_interval": 30,
+        "high_scan_interval": 10,
         "high_scan_start": "07:00:00",
         "low_scan_start": "22:00:00",
     }
@@ -74,43 +77,33 @@ class TestOnectaDataUpdateCoordinator:
     def test_high_scan_interval(self, mock_now, coordinator, mock_hass):
         """High scan interval should apply during high-frequency window."""
         mock_now.return_value = datetime(2023, 1, 1, 10, 0, 0)
-
-        expected = timedelta(minutes=10)
-        result = coordinator.determine_update_interval(mock_hass)
-        assert result == expected
+        assert coordinator.determine_update_interval(mock_hass) == timedelta(minutes=10)
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     def test_low_scan_interval(self, mock_now, coordinator, mock_hass):
         """Low scan interval should apply outside transition windows."""
         mock_now.return_value = datetime(2023, 1, 1, 23, 0, 0)
-
         with patch.object(coordinator, "in_between", side_effect=[False, False]):
-            expected = timedelta(minutes=30)
-            result = coordinator.determine_update_interval(mock_hass)
-            assert result == expected
+            assert coordinator.determine_update_interval(mock_hass) == timedelta(minutes=30)
 
     @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
     @patch("custom_components.daikin_onecta.coordinator.random")
     def test_transition_period_randomization(self, mock_random, mock_now, coordinator, mock_hass):
         """During transition, interval is randomized between floor and low interval."""
         mock_now.return_value = datetime(2023, 1, 1, 22, 5, 0)
-        mock_random.randint.return_value = 120  # 2 minutes
-
+        mock_random.randint.return_value = 120
         with patch.object(coordinator, "in_between", side_effect=[False, True]):
-            expected = timedelta(seconds=120)
-            result = coordinator.determine_update_interval(mock_hass)
-            assert result == expected
+            assert coordinator.determine_update_interval(mock_hass) == timedelta(seconds=120)
             mock_random.randint.assert_called_once_with(60, 1800)
 
-    @patch("custom_components.daikin_onecta.coordinator.dt_util.now")
-    def test_rate_limit_exceeded(self, mock_now, coordinator, mock_hass, mock_config_entry):
-        """When rate limit is exceeded, interval = retry_after + fallback (60s)."""
-        mock_now.return_value = datetime(2023, 1, 1, 23, 0, 0)
+    async def test_rate_limit_uses_update_failed_retry_after(self, coordinator, mock_config_entry):
+        """A Daikin rate limit should use the coordinator retry-after mechanism."""
+        daikin_api = mock_config_entry.runtime_data.daikin_api
+        daikin_api._last_patch_call = None
+        daikin_api.getCloudDeviceDetails = AsyncMock(side_effect=DaikinRateLimitError(3060))
 
-        # Simulate daily rate limit reached
-        mock_config_entry.runtime_data.daikin_api.rate_limits = {"remaining_day": 0, "retry_after": 3000}
+        with pytest.raises(UpdateFailed) as exc_info:
+            await coordinator._async_update_data()
 
-        with patch.object(coordinator, "in_between", side_effect=[False, False]):
-            expected = timedelta(seconds=3060)  # 3000 + 60
-            result = coordinator.determine_update_interval(mock_hass)
-            assert result == expected
+        assert exc_info.value.retry_after == 3060
+        assert coordinator.update_interval == timedelta(minutes=30)


### PR DESCRIPTION
Use Home Assistant's `UpdateFailed(retry_after=...)` mechanism for Daikin API rate limiting.

Changes:
- add a dedicated `DaikinRateLimitError` carrying the retry delay
- raise it for rate-limited GET requests instead of returning an empty device list
- translate it in the data coordinator to `UpdateFailed(retry_after=...)`
- stop changing the normal polling interval based on stored daily rate-limit state
- keep the existing persistent minute/day repair issues
- preserve a safety margin for daily-limit exhaustion and a minimum retry delay
- update coordinator tests to verify the retry-after behavior and that the normal polling interval remains unchanged

After a successful retry Home Assistant automatically resumes the configured polling cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of service rate limits when retrieving device details.
  * Rate-limit responses now provide an API-supplied retry delay instead of being treated as empty results.
  * Automatic updates resume using the standard 30-minute interval after a rate-limit event.

* **Reliability**
  * Temporary API throttling is reported more clearly, helping prevent repeated requests while access is limited.
  * Device updates now fail with actionable retry information when the service temporarily restricts requests.
  * Manual refreshes now use the standard update process for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->