### PR TITLE
Fix CI coverage reporting

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,6 @@ jobs:
             --durations=10 \
             -n auto \
             -p no:sugar \
-            --cov=api.calculator \
             --cov-report=xml \
             tests
       - name: Upload coverage reports to Codecov with GitHub Action


### PR DESCRIPTION
Fix the pytest coverage target used by GitHub Actions.

`setup.cfg` already configures pytest with `--cov=custom_components.daikin_onecta`, but the CI workflow overrode it with the unrelated `--cov=api.calculator`. This PR removes that incorrect override and keeps `--cov-report=xml`, so pytest measures the integration code and Codecov continues to receive `coverage.xml`.

No runtime code is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the automated test workflow to stop collecting coverage for the calculator module.
  * XML coverage report generation remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->