### PR TITLE
Improve typing and clean up config flow helpers

### DIFF
--- a/custom_components/daikin_onecta/button.py
+++ b/custom_components/daikin_onecta/button.py
@@ -1,4 +1,4 @@
-"""Component to interface with binary sensors."""
+"""Button platform for the Daikin Onecta integration."""
 import logging
 
 from homeassistant.components.button import ButtonEntity
@@ -9,7 +9,9 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .coordinator import OnectaDataUpdateCoordinator
 from .coordinator import OnectaRuntimeData
+from .device import DaikinOnectaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +36,12 @@ async def async_setup_entry(
 class DaikinRefreshButton(CoordinatorEntity, ButtonEntity):
     """Button to request an immediate device data update."""
 
-    def __init__(self, device, config_entry, coordinator):
+    def __init__(
+        self,
+        device: DaikinOnectaDevice,
+        config_entry: ConfigEntry,
+        coordinator: OnectaDataUpdateCoordinator,
+    ) -> None:
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{self._device.id}_refresh"

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -31,9 +31,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize Daikin Onecta options flow."""
         self.options = dict(config_entry.options)
 
-    async def async_step_init(self, user_input: dict[str, str] | None = None) -> FlowResult:
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
-        errors = {}
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
@@ -73,12 +74,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): BooleanSelector(),
                 }
             ),
-            errors=errors,
+            errors={},
         )
-
-    async def _update_options(self) -> FlowResult:
-        """Update config entry options."""
-        return self.async_create_entry(title="", data=self.options)
 
 
 class FlowHandler(
@@ -87,8 +84,8 @@ class FlowHandler(
 ):
     """Handle a config flow."""
 
-    """See https://developers.home-assistant.io/docs/core/platform/application_credentials/ """
-    """ https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/getting_started """
+    # See https://developers.home-assistant.io/docs/core/platform/application_credentials/
+    # and https://developer.cloud.daikineurope.com/docs/b0dffcaa-7b51-428a-bdff-a7c8a64195c0/getting_started
     VERSION = 1
     MINOR_VERSION = 2
     DOMAIN = DOMAIN

--- a/custom_components/daikin_onecta/config_flow.py
+++ b/custom_components/daikin_onecta/config_flow.py
@@ -31,9 +31,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize Daikin Onecta options flow."""
         self.options = dict(config_entry.options)
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle a flow initialized by the user."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -71,9 +71,7 @@ class DaikinApi:
         await self.session.async_ensure_token_valid()
         return self.session.token["access_token"]
 
-    async def doBearerRequest(
-        self, method: str, resource_url: str, options: str | None = None
-    ) -> Any:
+    async def doBearerRequest(self, method: str, resource_url: str, options: str | None = None) -> Any:
         async with self._cloud_lock:
             token = await self.async_get_access_token()
 

--- a/custom_components/daikin_onecta/daikin_api.py
+++ b/custom_components/daikin_onecta/daikin_api.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime
+from typing import Any
 
 from aiohttp import ClientError
 from homeassistant import config_entries
@@ -35,7 +36,7 @@ class DaikinApi:
         hass: core.HomeAssistant,
         entry: config_entries.ConfigEntry,
         implementation: config_entry_oauth2_flow.AbstractOAuth2Implementation,
-    ):
+    ) -> None:
         """Initialize a new Daikin Onecta API."""
         _LOGGER.debug("Initialing Daikin Onecta API...")
         self.hass = hass
@@ -51,7 +52,7 @@ class DaikinApi:
         self._last_patch_call: datetime | None = None
 
         # Store the limits as member so that we can add these to the diagnostics
-        self.rate_limits = {
+        self.rate_limits: dict[str, int] = {
             "minute": 0,
             "day": 0,
             "remaining_minutes": 0,
@@ -70,7 +71,9 @@ class DaikinApi:
         await self.session.async_ensure_token_valid()
         return self.session.token["access_token"]
 
-    async def doBearerRequest(self, method, resource_url, options=None):
+    async def doBearerRequest(
+        self, method: str, resource_url: str, options: str | None = None
+    ) -> Any:
         async with self._cloud_lock:
             token = await self.async_get_access_token()
 
@@ -150,6 +153,6 @@ class DaikinApi:
             return []
         return False
 
-    async def getCloudDeviceDetails(self):
+    async def getCloudDeviceDetails(self) -> list[dict[str, Any]]:
         """Get pure Device Data from the Daikin cloud devices."""
         return await self.doBearerRequest("GET", "/v1/gateway-devices")

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -49,9 +49,7 @@ class DaikinOnectaDevice:
             result = icu["value"]
         return result
 
-    def fill_device_info(
-        self, device_info: DeviceInfo, management_point_type: str
-    ) -> None:
+    def fill_device_info(self, device_info: DeviceInfo, management_point_type: str) -> None:
         manufacturer = {"manufacturer": "Daikin"}
         device_info.update(**manufacturer)
         management_points = self.daikin_data.get("managementPoints", [])
@@ -105,9 +103,7 @@ class DaikinOnectaDevice:
 
         return info
 
-    def async_register_ha_device(
-        self, hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> None:
+    def async_register_ha_device(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Eagerly create/update this device in the device registry.
 
         Called once from the coordinator, before any entity platform is set up
@@ -154,9 +150,7 @@ class DaikinOnectaDevice:
 
         return bool(res)
 
-    async def post(
-        self, id: str, embeddedId: str, dataPoint: str, value: Any
-    ) -> bool:
+    async def post(self, id: str, embeddedId: str, dataPoint: str, value: Any) -> bool:
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/" + dataPoint
         setOptions = json.dumps(value)
 
@@ -168,9 +162,7 @@ class DaikinOnectaDevice:
 
         return bool(res)
 
-    async def put(
-        self, id: str, embeddedId: str, dataPoint: str, value: Any = None
-    ) -> bool:
+    async def put(self, id: str, embeddedId: str, dataPoint: str, value: Any = None) -> bool:
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/" + dataPoint
         setOptions = None
         if value is not None:

--- a/custom_components/daikin_onecta/device.py
+++ b/custom_components/daikin_onecta/device.py
@@ -1,12 +1,15 @@
 import json
 import logging
+from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
+from .daikin_api import DaikinApi
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,13 +17,13 @@ _LOGGER = logging.getLogger(__name__)
 class DaikinOnectaDevice:
     """Class to represent and control one Daikin Onecta Device."""
 
-    def __init__(self, jsonData, apiInstance):
+    def __init__(self, jsonData: dict[str, Any], apiInstance: DaikinApi) -> None:
         """Initialize a new Daikin Onecta Device."""
         self.api = apiInstance
         # get name from climateControl
         self.daikin_data = jsonData
-        self.id = self.daikin_data["id"]
-        self.name = self.daikin_data["deviceModel"]
+        self.id: str = self.daikin_data["id"]
+        self.name: str = self.daikin_data["deviceModel"]
 
         management_points = self.daikin_data.get("managementPoints", [])
         for management_point in management_points:
@@ -46,7 +49,9 @@ class DaikinOnectaDevice:
             result = icu["value"]
         return result
 
-    def fill_device_info(self, device_info, management_point_type):
+    def fill_device_info(
+        self, device_info: DeviceInfo, management_point_type: str
+    ) -> None:
         manufacturer = {"manufacturer": "Daikin"}
         device_info.update(**manufacturer)
         management_points = self.daikin_data.get("managementPoints", [])
@@ -100,7 +105,9 @@ class DaikinOnectaDevice:
 
         return info
 
-    def async_register_ha_device(self, hass: HomeAssistant, config_entry) -> None:
+    def async_register_ha_device(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> None:
         """Eagerly create/update this device in the device registry.
 
         Called once from the coordinator, before any entity platform is set up
@@ -116,12 +123,23 @@ class DaikinOnectaDevice:
         )
         self.ha_device_id = entry.id
 
-    def setJsonData(self, desc):
+    def setJsonData(self, desc: dict[str, Any]) -> None:
         """Overwrite the json data for this device."""
         self.daikin_data = desc
-        _LOGGER.debug("Device '%s' received new data from the Daikin cloud, isCloudConnectionUp '%s'", self.name, self.available)
+        _LOGGER.debug(
+            "Device '%s' received new data from the Daikin cloud, isCloudConnectionUp '%s'",
+            self.name,
+            self.available,
+        )
 
-    async def patch(self, id, embeddedId, dataPoint, dataPointPath, value):
+    async def patch(
+        self,
+        id: str,
+        embeddedId: str,
+        dataPoint: str,
+        dataPointPath: str | None,
+        value: Any,
+    ) -> bool:
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/characteristics/" + dataPoint
         setBody = {"value": value}
         if dataPointPath:
@@ -132,11 +150,13 @@ class DaikinOnectaDevice:
 
         res = await self.api.doBearerRequest("PATCH", setPath, setOptions)
 
-        _LOGGER.debug(f"Result: {res}")
+        _LOGGER.debug("Result: %s", res)
 
-        return res
+        return bool(res)
 
-    async def post(self, id, embeddedId, dataPoint, value):
+    async def post(
+        self, id: str, embeddedId: str, dataPoint: str, value: Any
+    ) -> bool:
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/" + dataPoint
         setOptions = json.dumps(value)
 
@@ -144,11 +164,13 @@ class DaikinOnectaDevice:
 
         res = await self.api.doBearerRequest("POST", setPath, setOptions)
 
-        _LOGGER.debug(f"Result: {res}")
+        _LOGGER.debug("Result: %s", res)
 
-        return res
+        return bool(res)
 
-    async def put(self, id, embeddedId, dataPoint, value=None):
+    async def put(
+        self, id: str, embeddedId: str, dataPoint: str, value: Any = None
+    ) -> bool:
         setPath = "/v1/gateway-devices/" + id + "/management-points/" + embeddedId + "/" + dataPoint
         setOptions = None
         if value is not None:
@@ -158,6 +180,6 @@ class DaikinOnectaDevice:
 
         res = await self.api.doBearerRequest("PUT", setPath, setOptions)
 
-        _LOGGER.debug(f"Result: {res}")
+        _LOGGER.debug("Result: %s", res)
 
-        return res
+        return bool(res)


### PR DESCRIPTION
Improve typing in `device.py`, `daikin_api.py`, and the refresh button while keeping runtime behavior and entity identifiers unchanged.

Also clean up a few small issues found during the master review:
- type options-flow input as `dict[str, Any]` because selectors return numbers and booleans as well as strings
- remove the unused `_update_options()` helper
- replace dead triple-quoted string literals in `FlowHandler` with comments
- correct the button module description

Existing comments that document behavior have been preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type safety and consistency across Daikin Onecta device, API, button, and configuration workflows.
  - Device update operations now provide a clear success status.
  - Improved logging consistency for device communication.
  - Configuration options accept a broader range of valid input values.
  - Simplified internal configuration-flow handling and clarified OAuth-related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->